### PR TITLE
Channelling fix 2

### DIFF
--- a/src/main/java/ourstory/events/onTridentHit.java
+++ b/src/main/java/ourstory/events/onTridentHit.java
@@ -81,6 +81,7 @@ public class onTridentHit implements Listener {
 			return;
 
 		Entity target = event.getEntity();
+
 		// Fire the lightning
 		target.getWorld().strikeLightning(event.getEntity().getLocation()).setCausingPlayer((Player) ((Projectile) damager).getShooter());
 		target.getWorld().playSound(event.getEntity().getLocation(), Sound.ITEM_TRIDENT_THUNDER, 1000, 1);

--- a/src/main/java/ourstory/events/onTridentHit.java
+++ b/src/main/java/ourstory/events/onTridentHit.java
@@ -82,8 +82,15 @@ public class onTridentHit implements Listener {
 
 		Entity target = event.getEntity();
 
+		event.setCancelled(true);
 		// Fire the lightning
 		target.getWorld().strikeLightning(event.getEntity().getLocation());
 		target.getWorld().playSound(event.getEntity().getLocation(), Sound.ITEM_TRIDENT_THUNDER, 1000, 1);
+		new BukkitRunnable() {
+	        	@Override
+		        public void run() {
+		            target.damage(event.getDamage(), damager);
+		        }
+		    }.runTask(this);
 	}
 }

--- a/src/main/java/ourstory/events/onTridentHit.java
+++ b/src/main/java/ourstory/events/onTridentHit.java
@@ -81,16 +81,8 @@ public class onTridentHit implements Listener {
 			return;
 
 		Entity target = event.getEntity();
-
-		event.setCancelled(true);
 		// Fire the lightning
-		target.getWorld().strikeLightning(event.getEntity().getLocation());
+		target.getWorld().strikeLightning(event.getEntity().getLocation()).setCausingPlayer((Player) ((Projectile) damager).getShooter());
 		target.getWorld().playSound(event.getEntity().getLocation(), Sound.ITEM_TRIDENT_THUNDER, 1000, 1);
-		new BukkitRunnable() {
-	        	@Override
-		        public void run() {
-		            target.damage(event.getDamage(), damager);
-		        }
-		    }.runTask(this);
 	}
 }

--- a/src/main/java/ourstory/events/onTridentHit.java
+++ b/src/main/java/ourstory/events/onTridentHit.java
@@ -62,7 +62,7 @@ public class onTridentHit implements Listener {
 		Player player = (Player) trident.getShooter();
 
 		if (hitBlock.getType() == Material.LIGHTNING_ROD) {
-			player.getWorld().strikeLightning(event.getEntity().getLocation());
+			player.getWorld().strikeLightning(event.getEntity().getLocation()).setCausingPlayer(player);
 			player.getWorld().playSound(event.getEntity().getLocation(), Sound.ITEM_TRIDENT_THUNDER, 1000, 1);
 		}
 	}
@@ -73,14 +73,13 @@ public class onTridentHit implements Listener {
 	@EventHandler
 	public void onTridentHitEntity(EntityDamageByEntityEvent event) {
 		Entity damager = event.getDamager();
+		Entity target = event.getEntity();
 
 		if (!(damager instanceof Trident))
 			return;
 
 		if (!damager.getPersistentDataContainer().has(wipeTrident, PersistentDataType.INTEGER))
 			return;
-
-		Entity target = event.getEntity();
 
 		// Fire the lightning
 		target.getWorld().strikeLightning(event.getEntity().getLocation()).setCausingPlayer((Player) ((Projectile) damager).getShooter());


### PR DESCRIPTION
Added support to make lightning on lightning rods have the player as cause.

If the trident kills directly the entity, the death cause is reffered as "was impaled by" and not "was struck by". Thus, checking te cases if the player kills directly an entity isn't needed, as it completely changes how the game works. A way to do it anyway would be to delay the damages for the Entity check, with a runTaskLater. It can be found in early commits of the head repository's branch.