### PR TITLE
Dummy 2.0

### DIFF
--- a/src/main/java/ourstory/commands/Dummy.java
+++ b/src/main/java/ourstory/commands/Dummy.java
@@ -1,5 +1,13 @@
 package ourstory.commands;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.ArmorStand;
@@ -7,6 +15,7 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.plugin.Plugin;
+
 import io.papermc.paper.command.brigadier.BasicCommand;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import net.kyori.adventure.text.Component;
@@ -15,6 +24,17 @@ import ourstory.utils.Permissions;
 public class Dummy implements BasicCommand {
 
 	private Plugin p = Bukkit.getPluginManager().getPlugin("OurStory");
+
+	private final Map<String, String> DummyName = Map.of(
+			"Normal", "Classic ",
+			"Undead", "Undead ",
+			"Spider", "Crawling ",
+			"Marin", "Aquatic ");
+
+	private final Map<String, String> DummyTag = Map.of(
+			"Undead", "sensitive_smite",
+			"Spider", "sensitive_boa",
+			"Marin", "sensitive_impaling");
 
 	@Override
 	public void execute(CommandSourceStack sender, String[] args) {
@@ -31,9 +51,40 @@ public class Dummy implements BasicCommand {
 
 		ArmorStand dummy = (ArmorStand) w.spawnEntity(player.getLocation(), EntityType.ARMOR_STAND);
 
-		dummy.customName(Component.text("DPS Dummy"));
+		String base_name = "";
+		if (args.length > 0) {
+			for (String argus : args) {
+				if (DummyName.containsKey(argus))
+					base_name += DummyName.get(argus);
+				if (DummyTag.containsKey(argus))
+					dummy.setMetadata(DummyTag.get(argus), new FixedMetadataValue(p, true));
+			}
+		}
+		if (base_name.isEmpty())
+			base_name = "Normal ";
+
+		// Don't let duplicate name be there and sort them like : Undead Crawling Aquatic Dummy. Moreover,
+		// remove Classic if another one is there
+		String[] words = base_name.split("\\s+");
+		base_name = Arrays.stream(words)
+				.filter(word -> !(word.equals("Classic") && words.length > 1))
+				.distinct()
+				.sorted(Comparator.reverseOrder())
+				.collect(Collectors.joining(" "));
+		dummy.customName(Component.text(base_name + " Dummy"));
 		dummy.setCustomNameVisible(true);
 
 		dummy.setMetadata("isDummy", new FixedMetadataValue(p, true));
+
+	}
+
+	@Override
+	public Collection<String> suggest(CommandSourceStack commandSourceStack, String[] args) {
+		List<String> suggestions = new ArrayList<>();
+		suggestions.add("Normal");
+		suggestions.add("Undead");
+		suggestions.add("Spider");
+		suggestions.add("Marin");
+		return suggestions;
 	}
 }

--- a/src/main/java/ourstory/events/onDummyHit.java
+++ b/src/main/java/ourstory/events/onDummyHit.java
@@ -1,13 +1,24 @@
 package ourstory.events;
 
+import java.util.Map;
+
+import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.inventory.ItemStack;
+
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 
 public class onDummyHit implements Listener {
+
+	private final Map<String, Enchantment> EnchantmentsSensitivity = Map.of(
+			"sensitive_smite", Enchantment.SMITE,
+			"sensitive_boa", Enchantment.BANE_OF_ARTHROPODS,
+			"sensitive_impaling", Enchantment.IMPALING);
+
 	@EventHandler
 	public void dummyHit(EntityDamageByEntityEvent event) {
 		// Cancel if not player
@@ -15,12 +26,19 @@ public class onDummyHit implements Listener {
 			return;
 
 		// Cancel if not dummy
-		if (event.getEntity().getMetadata("isDummy").size() == 0)
+		if (event.getEntity().getMetadata("isDummy").isEmpty())
 			return;
 
 		event.setCancelled(true);
 
+		double base_damage = event.getDamage();
+		ItemStack itemInHand = ((Player) event.getDamager()).getInventory().getItemInMainHand();
+		for (String str : EnchantmentsSensitivity.keySet()) {
+			if (!event.getEntity().getMetadata(str).isEmpty())
+				base_damage += 2.5 * (itemInHand.containsEnchantment(EnchantmentsSensitivity.get(str)) ? itemInHand.getEnchantmentLevel(EnchantmentsSensitivity.get(str)) : 0);
+		}
+
 		Player p = (Player) event.getDamager();
-		p.sendMessage(Component.text("Dmg ").append(Component.text(String.format("%.2f", event.getDamage())).color(NamedTextColor.RED)));
+		p.sendMessage(Component.text(event.getEntity().getCustomName() + " : ").append(Component.text(String.format("%.2f", base_damage)).color(NamedTextColor.RED)));
 	}
 }

--- a/src/main/java/ourstory/events/onDummyHit.java
+++ b/src/main/java/ourstory/events/onDummyHit.java
@@ -2,6 +2,7 @@ package ourstory.events;
 
 import java.util.Map;
 
+import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -11,6 +12,7 @@ import org.bukkit.inventory.ItemStack;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import ourstory.utils.EnchantItem;
 
 public class onDummyHit implements Listener {
 
@@ -33,10 +35,19 @@ public class onDummyHit implements Listener {
 
 		double base_damage = event.getDamage();
 		ItemStack itemInHand = ((Player) event.getDamager()).getInventory().getItemInMainHand();
+
+		// Ajout d'un moyen de suppression d'un dummy
+		if (itemInHand.getType().equals(Material.COD) && event.getDamager().isOp())
+			event.getEntity().remove();
+
+		// Ajout des dégâts pour chaque enchants présent sur le dummy et la meta data
 		for (String str : EnchantmentsSensitivity.keySet()) {
 			if (!event.getEntity().getMetadata(str).isEmpty())
 				base_damage += 2.5 * (itemInHand.containsEnchantment(EnchantmentsSensitivity.get(str)) ? itemInHand.getEnchantmentLevel(EnchantmentsSensitivity.get(str)) : 0);
 		}
+
+		// Gestion de final_damage
+		base_damage *= 1 + (0.05 * EnchantItem.getEnchantAmount(itemInHand, "final_damage"));
 
 		Player p = (Player) event.getDamager();
 		p.sendMessage(Component.text(event.getEntity().getCustomName() + " : ").append(Component.text(String.format("%.2f", base_damage)).color(NamedTextColor.RED)));


### PR DESCRIPTION
Added support for the creation of multi typed dummies, taking more damage from (non exclusives) : Bane of Arthropods, Smite, Impaling and Final Damage.

Added a way to remove (only for Op users) a dummy by smacking it with a cod (raw only) 
**to perpetuate the ancient, almost mythical beliefs and methods passed down through the ages, to embark upon a challenge so grandiose that even the gods themselves might raise an eyebrow in disbelief ! 🙃**

2 Issues still remains : 
- Shooting an arrow at a Dummy destroys it
- Every server restart will reset all metadata (especially isDummy and all the checks on the dummies). This needs to be fixed at all costs, to avoid needing to respawn them every time at launch.

![](https://cdn.discordapp.com/attachments/1296939645002715166/1310414683592724500/c432aaed9c70fae25fc151b5e4548fb8.png?ex=67452246&is=6743d0c6&hm=370135b7943c0009570817b2b15b29af9d3f8985d343d5a9833e5132f2d3afd5&)