### PR TITLE
Added Reach enchantment

### DIFF
--- a/datapack/OurStory/data/minecraft/tags/enchantment/in_enchanting_table.json
+++ b/datapack/OurStory/data/minecraft/tags/enchantment/in_enchanting_table.json
@@ -5,6 +5,7 @@
     "ourstory:leech",
     "ourstory:phoenix",
     "ourstory:xp_hunter",
+    "ourstory:reach",
     "ourstory:arrow_rain"
   ]
 }

--- a/datapack/OurStory/data/ourstory/enchantment/reach.json
+++ b/datapack/OurStory/data/ourstory/enchantment/reach.json
@@ -1,0 +1,25 @@
+{
+	"description": "Reach",
+	"supported_items": [
+		"minecraft:enchanted_book",
+		"minecraft:book"
+	],
+	"primary_items": [
+		"minecraft:enchanted_book",
+		"minecraft:book"
+	],
+	"weight": 1,
+	"max_level": 1,
+	"min_cost": {
+		"base": 28,
+		"per_level_above_first": 0
+	},
+	"max_cost": {
+		"base": 30,
+		"per_level_above_first": 0
+	},
+	"anvil_cost": 6,
+	"slots": [
+		"armor"
+	]
+}

--- a/src/main/java/ourstory/Main.java
+++ b/src/main/java/ourstory/Main.java
@@ -51,7 +51,7 @@ public class Main extends JavaPlugin {
 		 * Registers all events
 		 */
 		Listener[] eventsToRegister = {
-				new onArrowRain(), new onBossDeath(), new onBossHit(), new onDummyHit(), new onEntityDeath(),
+				new onReachEquip(), new onArrowRain(), new onBossDeath(), new onBossHit(), new onDummyHit(), new onEntityDeath(),
 				new onEntityHit(), new onFinalDamage(), new onHeadDrop(), new onItemConsume(),
 				new onMineAmethyst(), new onMineDeepslate(), new onPhoenixDeath(), new onPlayerDeath(),
 				new onPlayerInteract(), new onPlayerJoin(), new onPlayerPlace(), new onPlayerSit(),

--- a/src/main/java/ourstory/events/onReachEquip.java
+++ b/src/main/java/ourstory/events/onReachEquip.java
@@ -1,0 +1,44 @@
+package ourstory.events;
+
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.inventory.ItemStack;
+
+import com.destroystokyo.paper.event.player.PlayerArmorChangeEvent;
+
+import ourstory.utils.EnchantItem;
+
+/**
+ *
+ * @author aurel
+ */
+public class onReachEquip implements Listener {
+
+	@EventHandler
+	public void onPlayerChangeArmor(PlayerArmorChangeEvent event) {
+		Player player = event.getPlayer();
+		int totalReachLevels = 0;
+		ItemStack[] armorContents = player.getInventory().getArmorContents();
+
+		for (ItemStack armor : armorContents)
+			totalReachLevels += EnchantItem.getEnchantAmount(armor, "reach");
+
+		if (totalReachLevels > 4)
+			totalReachLevels = 4;
+		applyReachModifier(player, totalReachLevels);
+	}
+
+	private void applyReachModifier(Player player, double ReachLevel) {
+		NamespacedKey ReachKey = new NamespacedKey(Bukkit.getPluginManager().getPlugin("OurStory"), "reach_bonus");
+		if (player.getAttribute(Attribute.PLAYER_BLOCK_INTERACTION_RANGE) != null)
+			player.getAttribute(Attribute.PLAYER_BLOCK_INTERACTION_RANGE).removeModifier(ReachKey);
+
+		AttributeModifier buff = new AttributeModifier(ReachKey, ReachLevel, AttributeModifier.Operation.ADD_NUMBER);
+		player.getAttribute(Attribute.PLAYER_BLOCK_INTERACTION_RANGE).addModifier(buff);
+	}
+}


### PR DESCRIPTION
TESTED ONLY IN 1.21.1

Worked like a charm.
Upgraded block reach from 4.5 up to 8.5 blocks.
Does not change entity hit range
When in Creative mode, the reach is naturally 0.5 blocks higher, so it will range from 5 to 9.