### PR TITLE
Added Ravenous Vortex Skill

### DIFF
--- a/src/main/java/ourstory/commands/Cast.java
+++ b/src/main/java/ourstory/commands/Cast.java
@@ -17,7 +17,8 @@ public class Cast implements BasicCommand {
 			"ArrowWall", new ArrowWall(),
 			"Summon", new Summon(),
 			"Wave", new Wave(),
-			"WitherRage", new WitherRage());
+			"WitherRage", new WitherRage(),
+			"RavenousVortex", new RavenousVortex());
 
 	@Override
 	public void execute(CommandSourceStack sender, String[] args) {

--- a/src/main/java/ourstory/skills/RavenousVortex.java
+++ b/src/main/java/ourstory/skills/RavenousVortex.java
@@ -1,0 +1,109 @@
+package ourstory.skills;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Particle;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.scheduler.BukkitRunnable;
+
+/**
+ *
+ * @author aurel
+ */
+public class RavenousVortex implements Skills {
+
+	static NamespacedKey GravityKey = new NamespacedKey(Bukkit.getPluginManager().getPlugin("OurStory"), "boss_ravenouos_vortex");
+	static double effectRange = 10;
+	static double effectGravityRadius = 2;
+
+	@Override
+	public void cast(Entity caster, List<Entity> targets) {
+
+		new BukkitRunnable() {
+			double effectDuration = 50;
+			List<Location> nearbyEntitiesLocation = caster.getNearbyEntities(effectRange, 2, effectRange)
+					.stream()
+					.filter(entity -> entity instanceof LivingEntity)
+					.map(entity -> entity.getLocation())
+					.collect(Collectors.toList());
+			HashSet<LivingEntity> oldAffectedEntities = new HashSet<>();
+			HashSet<LivingEntity> oldFallDownEntities = new HashSet<>();
+
+			@Override
+			public void run() {
+				if (effectDuration <= 0) {
+					clearEffect(oldAffectedEntities);
+					clearEffect(oldFallDownEntities);
+					this.cancel();
+					return;
+				}
+				effectDuration--;
+				HashSet<LivingEntity> newlyAffectedEntities = new HashSet<>();
+				HashSet<LivingEntity> newlyFallDownEntities = new HashSet<>();
+
+				for (Location effectLocation : nearbyEntitiesLocation) {
+					handleEffect(oldAffectedEntities, newlyAffectedEntities, -1, 0.5, Particle.FLAME, effectLocation, 1);
+					handleEffect(oldFallDownEntities, newlyFallDownEntities, 99, 2.5, Particle.GLOW, effectLocation.clone().add(new Location(effectLocation.getWorld(), 0, 17.5, 0)), 1);
+					playCircleEffect(effectLocation.clone().add(new Location(effectLocation.getWorld(), 0, 17.5, 0)), effectGravityRadius * 1.5, Particle.GLOW);
+					playCircleEffect(effectLocation.clone().add(new Location(effectLocation.getWorld(), 0, 20, 0)), effectGravityRadius * 2, Particle.GLOW);
+				}
+			}
+		}.runTaskTimer(plugin, 0, 1);
+	}
+
+	public static void handleEffect(HashSet<LivingEntity> oldSet, HashSet<LivingEntity> newSet, int strength, double radiusheight, Particle part, Location loc, double radius_mult) {
+		newSet.addAll(loc.getNearbyEntities(effectGravityRadius, radiusheight, effectGravityRadius)
+				.stream()
+				.filter(entity -> entity instanceof LivingEntity)
+				.map(entity -> (LivingEntity) entity)
+				.collect(Collectors.toCollection(HashSet::new)));
+		HashSet<LivingEntity> difference = new HashSet<>(oldSet);
+		difference.removeAll(newSet);
+		difference.forEach(entity -> {
+			removeEffect(entity);
+		});
+		oldSet.clear();
+		oldSet.addAll(newSet);
+		newSet.forEach(entity -> {
+			applyEffect(entity, strength);
+		});
+		playCircleEffect(loc.clone().add(0, -radiusheight, 0), effectGravityRadius * radius_mult, part);
+	}
+
+	public static void clearEffect(HashSet<LivingEntity> oldSet) {
+		oldSet.forEach(entity -> {
+			removeEffect(entity);
+		});
+	}
+
+	public static void removeEffect(LivingEntity entity) {
+		if (entity.getAttribute(Attribute.GENERIC_GRAVITY) != null)
+			entity.getAttribute(Attribute.GENERIC_GRAVITY).removeModifier(GravityKey);
+	}
+
+	public static void applyEffect(LivingEntity entity, int strength) {
+		removeEffect(entity);
+
+		AttributeModifier buff = new AttributeModifier(GravityKey, strength, AttributeModifier.Operation.ADD_NUMBER);
+		entity.getAttribute(Attribute.GENERIC_GRAVITY).addModifier(buff);
+	}
+
+	private static void playCircleEffect(Location loc, double radius, Particle particle) {
+		for (double angle = 0; angle < 2 * Math.PI; angle += Math.PI / 45) {
+			final double x = radius * Math.cos(angle);
+			final double z = radius * Math.sin(angle);
+
+			loc.add(x, 0, z);
+			loc.getWorld().spawnParticle(particle, loc, 1, 0, 0, 0, 0);
+			loc.subtract(x, 0, z);
+		}
+	}
+}

--- a/src/main/java/ourstory/skills/RavenousVortex.java
+++ b/src/main/java/ourstory/skills/RavenousVortex.java
@@ -11,7 +11,7 @@ import org.bukkit.Particle;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
 /**
@@ -31,11 +31,11 @@ public class RavenousVortex implements Skills {
 			double effectDuration = 50;
 			List<Location> nearbyEntitiesLocation = caster.getNearbyEntities(effectRange, 2, effectRange)
 					.stream()
-					.filter(entity -> entity instanceof LivingEntity)
+					.filter(entity -> entity instanceof Player)
 					.map(entity -> entity.getLocation())
 					.collect(Collectors.toList());
-			HashSet<LivingEntity> oldAffectedEntities = new HashSet<>();
-			HashSet<LivingEntity> oldFallDownEntities = new HashSet<>();
+			HashSet<Player> oldAffectedEntities = new HashSet<>();
+			HashSet<Player> oldFallDownEntities = new HashSet<>();
 
 			@Override
 			public void run() {
@@ -46,26 +46,26 @@ public class RavenousVortex implements Skills {
 					return;
 				}
 				effectDuration--;
-				HashSet<LivingEntity> newlyAffectedEntities = new HashSet<>();
-				HashSet<LivingEntity> newlyFallDownEntities = new HashSet<>();
+				HashSet<Player> newlyAffectedEntities = new HashSet<>();
+				HashSet<Player> newlyFallDownEntities = new HashSet<>();
 
 				for (Location effectLocation : nearbyEntitiesLocation) {
-					handleEffect(oldAffectedEntities, newlyAffectedEntities, -1, 0.5, Particle.FLAME, effectLocation, 1);
-					handleEffect(oldFallDownEntities, newlyFallDownEntities, 99, 2.5, Particle.GLOW, effectLocation.clone().add(new Location(effectLocation.getWorld(), 0, 17.5, 0)), 1);
-					playCircleEffect(effectLocation.clone().add(new Location(effectLocation.getWorld(), 0, 17.5, 0)), effectGravityRadius * 1.5, Particle.GLOW);
-					playCircleEffect(effectLocation.clone().add(new Location(effectLocation.getWorld(), 0, 20, 0)), effectGravityRadius * 2, Particle.GLOW);
+					handleEffect(oldAffectedEntities, newlyAffectedEntities, -1, 0.6, Particle.FLAME, effectLocation, 1);
+					handleEffect(oldFallDownEntities, newlyFallDownEntities, 99, 3, Particle.GLOW, effectLocation.clone().add(new Location(effectLocation.getWorld(), 0, 23, 0)), 1);
+					playCircleEffect(effectLocation.clone().add(new Location(effectLocation.getWorld(), 0, 23, 0)), effectGravityRadius * 1.5, Particle.GLOW);
+					playCircleEffect(effectLocation.clone().add(new Location(effectLocation.getWorld(), 0, 26, 0)), effectGravityRadius * 2, Particle.GLOW);
 				}
 			}
 		}.runTaskTimer(plugin, 0, 1);
 	}
 
-	public static void handleEffect(HashSet<LivingEntity> oldSet, HashSet<LivingEntity> newSet, int strength, double radiusheight, Particle part, Location loc, double radius_mult) {
+	public static void handleEffect(HashSet<Player> oldSet, HashSet<Player> newSet, int strength, double radiusheight, Particle part, Location loc, double radius_mult) {
 		newSet.addAll(loc.getNearbyEntities(effectGravityRadius, radiusheight, effectGravityRadius)
 				.stream()
-				.filter(entity -> entity instanceof LivingEntity)
-				.map(entity -> (LivingEntity) entity)
+				.filter(entity -> entity instanceof Player)
+				.map(entity -> (Player) entity)
 				.collect(Collectors.toCollection(HashSet::new)));
-		HashSet<LivingEntity> difference = new HashSet<>(oldSet);
+		HashSet<Player> difference = new HashSet<>(oldSet);
 		difference.removeAll(newSet);
 		difference.forEach(entity -> {
 			removeEffect(entity);
@@ -78,18 +78,18 @@ public class RavenousVortex implements Skills {
 		playCircleEffect(loc.clone().add(0, -radiusheight, 0), effectGravityRadius * radius_mult, part);
 	}
 
-	public static void clearEffect(HashSet<LivingEntity> oldSet) {
+	public static void clearEffect(HashSet<Player> oldSet) {
 		oldSet.forEach(entity -> {
 			removeEffect(entity);
 		});
 	}
 
-	public static void removeEffect(LivingEntity entity) {
+	public static void removeEffect(Player entity) {
 		if (entity.getAttribute(Attribute.GENERIC_GRAVITY) != null)
 			entity.getAttribute(Attribute.GENERIC_GRAVITY).removeModifier(GravityKey);
 	}
 
-	public static void applyEffect(LivingEntity entity, int strength) {
+	public static void applyEffect(Player entity, int strength) {
 		removeEffect(entity);
 
 		AttributeModifier buff = new AttributeModifier(GravityKey, strength, AttributeModifier.Operation.ADD_NUMBER);

--- a/src/main/java/ourstory/skills/RavenousVortex.java
+++ b/src/main/java/ourstory/skills/RavenousVortex.java
@@ -20,7 +20,7 @@ import org.bukkit.scheduler.BukkitRunnable;
  */
 public class RavenousVortex implements Skills {
 
-	static NamespacedKey GravityKey = new NamespacedKey(Bukkit.getPluginManager().getPlugin("OurStory"), "boss_ravenouos_vortex");
+	static NamespacedKey GravityKey = new NamespacedKey(Bukkit.getPluginManager().getPlugin("OurStory"), "boss_ravenous_vortex");
 	static double effectRange = 10;
 	static double effectGravityRadius = 2;
 


### PR DESCRIPTION
--- Commit ea00bf5 ---

Add a new Skill (not linked to boss yet)

Will scan for entities around the boss, and apply an effect on this place.

It will reverse Gravity of entities inside it, and 15t o 20 blocks higher, force 100 times the gravity, to stomp entites on the ground.
Will stomp 3 times (around 2.5 secs for now)

might upgrade it by 5 or 10 blocks to make it more lethal.

For the real boss, should replace LivingEntity by Player everywhere to ensure the boss and his minions aren't caught in the gravity flux

--- Commit c90b9c0 ---

- Added 5 more blocks to height (to deal 2 heart three times, with the best armor in the game)
- Lift Players 1 time, then stomp them (x2) then will lift a bit higher, without stomping.
- Made the skill works only on Players. Needs to be tested in real time, on the server. Worked perfectly on any LivingEntity just before. Should works perfectly fine