### PR TITLE
Improving boss type access by generic inference.

### DIFF
--- a/src/main/java/ourstory/goal/AbstractBossGoal.java
+++ b/src/main/java/ourstory/goal/AbstractBossGoal.java
@@ -1,0 +1,24 @@
+package ourstory.goal;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Mob;
+import com.destroystokyo.paper.entity.ai.Goal;
+import com.destroystokyo.paper.entity.ai.GoalKey;
+import ourstory.bosses.Boss;
+
+public abstract class AbstractBossGoal<T extends Boss> implements Goal<Mob> {
+	protected final T boss;
+
+	public AbstractBossGoal(final T boss) {
+		this.boss = boss;
+	}
+
+	abstract String getPhaseKey();
+
+	@Override
+	public GoalKey<Mob> getKey() {
+		return GoalKey.of(
+				Mob.class,
+				new NamespacedKey("ourstory", this.getPhaseKey()));
+	}
+}


### PR DESCRIPTION
L'idée c'est de spécialiser le type générique de AbstractBossGoal par la classe du boss en question pour y avoir un accès full typé. Par exemple :

```java
public class DivineDescentPhase extends AbstractBossGoal<HolyCow> {
    public DivineDescentPhase(final HolyCow boss) {
        super(boss);
    }
    (...)
    @Override
    public boolean shouldActivate() {
        return boss.getState() == HolyCow.State.DESCENDING;
    }
}
```