### PR TITLE
Security and code-quality overhaul

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,4 +27,4 @@ jobs:
       name: Upload Artifact
       with:
         name: OurStory
-        path: target/OurStory.jar
+        path: target/Ourstory.jar

--- a/configs/plugin.yml
+++ b/configs/plugin.yml
@@ -1,6 +1,6 @@
 name: OurStory
 description: OurStory's main plugin
-version: 2.0.8
+version: 2.0.9
 api-version: '1.20'
 author: aze31130
 website: https://www.aze.sh
@@ -9,3 +9,35 @@ main: ourstory.Main
 
 depend:
   - Vault
+
+permissions:
+  ourstory.boss:
+    description: Spawn a boss via /boss
+    default: op
+  ourstory.cast:
+    description: Cast a spell via /cast
+    default: op
+  ourstory.chall:
+    description: Display advancement progress via /chall
+    default: true
+  ourstory.count:
+    description: Count items in inventory via /count
+    default: true
+  ourstory.dummy:
+    description: Spawn a training dummy via /dummy
+    default: op
+  ourstory.goal:
+    description: Spawn a Holy Cow boss via /goal
+    default: op
+  ourstory.guild:
+    description: Use guild commands
+    default: true
+  ourstory.itemlock:
+    description: Toggle drop-lock on the held item via /itemlock
+    default: true
+  ourstory.split:
+    description: Split an enchanted book via /split
+    default: true
+  ourstory.test:
+    description: Internal /test command
+    default: op

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,6 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>21</maven.compiler.source>
 		<maven.compiler.target>21</maven.compiler.target>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
 				<directory>configs</directory>
 				<includes>
 					<include>plugin.yml</include>
+					<include>messages.json</include>
 				</includes>
 			</resource>
 		</resources>

--- a/src/main/java/ourstory/Main.java
+++ b/src/main/java/ourstory/Main.java
@@ -7,7 +7,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Listener;
-import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.json.JSONObject;
@@ -17,24 +16,31 @@ import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
 import ourstory.bosses.Instance;
 import ourstory.commands.*;
 import ourstory.events.*;
+import ourstory.guilds.Guild;
 import ourstory.recipes.*;
 import ourstory.utils.FileUtils;
-import ourstory.guilds.Guild;
 
 public class Main extends JavaPlugin {
 	public static final String namespace = "ourstory";
-	public static File configDir = new File(System.getProperty("user.dir") + "/plugins/Ourstory");
 
-	// public static List<Guild> guilds = FileUtils.loadGuilds("./guilds.json");
-	public static JSONObject messages = FileUtils.loadJsonObject("messages.json");
+	public static Main plugin;
+	public static File configDir;
+	public static JSONObject messages = new JSONObject();
 	public static List<Guild> guilds = new ArrayList<>();
 	public static Instance runningInstance;
 
 	@Override
 	public void onEnable() {
+		plugin = this;
+		configDir = getDataFolder();
+		if (!configDir.exists() && !configDir.mkdirs())
+			getLogger().warning("Could not create plugin data folder: " + configDir);
+
+		saveResource("messages.json", false);
+		messages = FileUtils.loadJsonObject("messages.json");
+
 		Bukkit.getConsoleSender().sendMessage("Loading Ourstory...");
 
-		// Register task for running the periodic tip broadcast
 		new BukkitRunnable() {
 			@Override
 			public void run() {
@@ -42,9 +48,6 @@ public class Main extends JavaPlugin {
 			}
 		}.runTaskTimer(this, 0L, 360000L);
 
-		/*
-		 * Registers all events
-		 */
 		Listener[] eventsToRegister = {
 				new onArrowRain(), new onBossDeath(), new onBossHit(), new onDisplayItem(), new onDummyHit(), new onEntityDeath(),
 				new onEntityHit(), new onFinalDamage(), new onHeadDrop(), new onItemConsume(), new onMineAmethyst(),
@@ -56,31 +59,22 @@ public class Main extends JavaPlugin {
 		for (Listener event : eventsToRegister)
 			Bukkit.getPluginManager().registerEvents(event, this);
 
-		/*
-		 * Registers all commands
-		 */
 		Map<String, BasicCommand> commandsToRegister = Map.of(
 				"goal", new MobGoalCommand(),
 				"boss", new Boss(),
 				"dummy", new Dummy(),
-				// "reset", new Reset(),
-				"test", new Test(),
 				"split", new Split(),
-				// "rankup", new RankUp(),
 				"count", new Count(),
 				"chall", new Chall(),
 				"itemlock", new CancelDrop(),
 				"cast", new Cast());
 
-		var manager = this.getLifecycleManager();
-		manager.registerEventHandler(LifecycleEvents.COMMANDS, event -> {
+		getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event -> {
 			final Commands commands = event.registrar();
-
 			for (Entry<String, BasicCommand> command : commandsToRegister.entrySet())
 				commands.register(command.getKey(), command.getValue());
 		});
 
-		// Registers custom recipe
 		CraftingTable.createCustomRecipes();
 		StoneCutter.createCustomRecipes();
 		Furnace.createCustomRecipes();
@@ -89,7 +83,5 @@ public class Main extends JavaPlugin {
 	@Override
 	public void onDisable() {
 		Bukkit.getConsoleSender().sendMessage("Disabling Ourstory...");
-
-		// Stop Exporter server, saves guilds
 	}
 }

--- a/src/main/java/ourstory/bosses/HolyCow.java
+++ b/src/main/java/ourstory/bosses/HolyCow.java
@@ -1,67 +1,36 @@
 package ourstory.bosses;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import org.bukkit.Bukkit;
-import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Mob;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import com.destroystokyo.paper.entity.ai.MobGoals;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import ourstory.goal.ChargeClosestGoal;
 import ourstory.goal.SleepGoal;
-import ourstory.spells.Annihilation;
-import ourstory.spells.Spell;
 
 public class HolyCow extends Boss {
-	/**
-	 * @param mob : Entity attached to the boss
-	 * @param engaged : The players involved in the fight.
-	 */
 	public HolyCow(Mob mob, List<Player> engagedPlayers, int level) {
 		super("Holy Cow", mob, engagedPlayers, level);
 	}
 
-	/**
-	 * Register different behaviours of the boss. These can be seen as phases. Each phase defines a set
-	 * of spells that the boss can use.
-	 */
+	@Override
 	public void registerGoals(MobGoals goals) {
 		goals.removeAllGoals(this.entity);
-		goals.addGoal(this.entity, 0, new SleepGoal(this)); // Phase 1
-		// goals.addGoal(this.entity, 1, new ChargeClosestGoal(this)); // Phase 2
+		goals.addGoal(this.entity, 0, new SleepGoal(this));
 	}
-
-	// @Override
-	// public Set<Spell> getSpells(int phase) {
-	// Set<Spell> set = new HashSet<>();
-	// // La l'idée c'est de choisir en fonction de la phase les spells qu'on veut.
-	// if (phase == 0) {
-	// set.add(new Annihilation(mob, engagedPlayers, level));
-	// }
-	// return set;
-	// }
 
 	@Override
 	public void onSpawn() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'onSpawn'");
+		// no-op: spawn behaviour not yet implemented
 	}
 
 	@Override
 	public void onHit(EntityDamageByEntityEvent event) {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'onHit'");
+		// no-op: hit reaction not yet implemented
 	}
 
 	@Override
 	public void onDeath(EntityDeathEvent event) {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'onDeath'");
+		// no-op: death sequence not yet implemented
 	}
 }

--- a/src/main/java/ourstory/bosses/Instance.java
+++ b/src/main/java/ourstory/bosses/Instance.java
@@ -1,5 +1,6 @@
 package ourstory.bosses;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
@@ -7,8 +8,8 @@ import java.util.Map;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitTask;
+import ourstory.Main;
 
 public class Instance {
 	public Boss boss;
@@ -20,9 +21,7 @@ public class Instance {
 
 	private BukkitTask timer;
 
-	private static final List<Integer> timerWarnings = List.of(15, 10, 5, 3, 2, 1);
-	private Plugin p = Bukkit.getPluginManager().getPlugin("OurStory");
-
+	private static final List<Integer> TIMER_WARNINGS = List.of(15, 10, 5, 3, 2, 1);
 
 	public Instance(Boss boss, List<Player> players, int durationMinutes, int maxRespawn, String arena) {
 		this.boss = boss;
@@ -33,41 +32,45 @@ public class Instance {
 
 		this.players = new HashMap<>();
 
-		// Init damage hashmap and warp player to arena
+		if (this.arena == null) {
+			Bukkit.getLogger().warning("Boss instance arena world '" + arena + "' does not exist; instance disabled.");
+			return;
+		}
+
 		for (Player p : players) {
 			this.players.put(p, 0);
 			p.teleport(this.arena.getSpawnLocation());
 		}
 
-		// Exec reminder task every 60 seconds
-		timer = Bukkit.getScheduler().runTaskTimer(p, () -> {
+		timer = Bukkit.getScheduler().runTaskTimer(Main.plugin, () -> {
 			LocalDateTime now = LocalDateTime.now();
-			int minutesLeft = (int) java.time.Duration.between(now, this.limit).toMinutes();
+			int minutesLeft = (int) Duration.between(now, this.limit).toMinutes();
 
-			if (timerWarnings.contains(minutesLeft))
+			if (TIMER_WARNINGS.contains(minutesLeft))
 				for (Player p : this.players.keySet())
-					p.sendMessage(minutesLeft + " minutes lef to defeat " + this.boss.name);
+					p.sendMessage(minutesLeft + " minutes left to defeat " + this.boss.name);
 
-			if (minutesLeft <= 0) {
+			if (minutesLeft <= 0)
 				fail();
-			}
 		}, 0, 20 * 60);
 	}
 
 	public void fail() {
-		this.timer.cancel();
+		if (this.timer != null)
+			this.timer.cancel();
 		this.boss.entity.remove();
 
 		World spawn = Bukkit.getWorld("world");
-
 		for (Player p : this.players.keySet()) {
-			p.sendMessage("You failed to defeat" + this.boss.name + " in time. Warping you back...");
-			p.teleport(spawn.getSpawnLocation());
+			p.sendMessage("You failed to defeat " + this.boss.name + " in time. Warping you back...");
+			if (spawn != null)
+				p.teleport(spawn.getSpawnLocation());
 		}
 	}
 
 	public void finish() {
-		this.timer.cancel();
+		if (this.timer != null)
+			this.timer.cancel();
 		this.boss.entity.remove();
 	}
 }

--- a/src/main/java/ourstory/bosses/Talven.java
+++ b/src/main/java/ourstory/bosses/Talven.java
@@ -52,20 +52,17 @@ public class Talven extends Boss {
 
 	@Override
 	public void onSpawn() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'onSpawn'");
+		// no-op: spawn sequence still under development (see commented WIP below)
 	}
 
 	@Override
 	public void onHit(EntityDamageByEntityEvent event) {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'onHit'");
+		// no-op: phase transitions still under development (see commented WIP below)
 	}
 
 	@Override
 	public void onDeath(EntityDeathEvent event) {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'onDeath'");
+		// no-op: death sequence still under development (see commented WIP below)
 	}
 
 	// private Plugin p = Bukkit.getPluginManager().getPlugin("OurStory");

--- a/src/main/java/ourstory/commands/Boss.java
+++ b/src/main/java/ourstory/commands/Boss.java
@@ -1,24 +1,18 @@
 package ourstory.commands;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-import io.papermc.paper.command.brigadier.BasicCommand;
-import io.papermc.paper.command.brigadier.CommandSourceStack;
 import org.bukkit.Bukkit;
-import org.bukkit.entity.Cow;
 import org.bukkit.entity.IronGolem;
 import org.bukkit.entity.Mob;
 import org.bukkit.entity.Player;
-import org.bukkit.entity.Zombie;
-import ourstory.Main;
-import ourstory.bosses.HolyCow;
-import ourstory.bosses.Instance;
+import io.papermc.paper.command.brigadier.BasicCommand;
+import io.papermc.paper.command.brigadier.CommandSourceStack;
 import ourstory.bosses.Talven;
 import ourstory.utils.Permissions;
 
 public class Boss implements BasicCommand {
-	private final List<String> availableBoss = List.of("Talven");
+	private static final List<String> AVAILABLE_BOSSES = List.of("Talven");
 
 	@Override
 	public void execute(CommandSourceStack sender, String[] args) {
@@ -30,45 +24,29 @@ public class Boss implements BasicCommand {
 			return;
 		}
 
-		Player playerSender = (Player) sender.getExecutor();
-		Mob test = (Mob) playerSender.getWorld().spawn(sender.getLocation(), IronGolem.class);
-		ourstory.bosses.Boss boss = new Talven("Talven", test, List.of(playerSender), 0);
+		String bossName = args[0];
+		if (!AVAILABLE_BOSSES.contains(bossName)) {
+			sender.getSender().sendMessage("Unknown boss: " + bossName);
+			return;
+		}
+
+		if (!(sender.getExecutor() instanceof Player playerSender)) {
+			sender.getSender().sendMessage("Only a player can run this command !");
+			return;
+		}
+
+		Mob mob = (Mob) playerSender.getWorld().spawn(sender.getLocation(), IronGolem.class);
+		ourstory.bosses.Boss boss = new Talven(bossName, mob, List.of(playerSender), 0);
 		boss.registerGoals(Bukkit.getServer().getMobGoals());
-
-		// String bossName = args[0];
-
-		// ourstory.bosses.Boss boss = null;
-		// // arena.getSpawnLocation().set(0, 100, 0)
-		// switch (bossName) {
-		// case "Talven":
-		// // boss = new Talven(sender.getLocation());
-		// // boss.onSpawn();
-		// break;
-
-		// default:
-		// sender.getSender().sendMessage("This boss does not exist !");
-		// return;
-		// }
-
-		// // Register boss instance
-		// List<Player> players = new ArrayList<>();
-		// players.add((Player) sender.getSender());
-		// Instance instance = new Instance(boss, players, 10, 5, "world");
-
-		// Main.runningInstance = instance;
 	}
 
-	/*
-	 * /boss <bossname>
-	 */
 	@Override
 	public List<String> suggest(CommandSourceStack commandSourceStack, String[] args) {
 		if (args.length == 0)
-			return availableBoss;
+			return AVAILABLE_BOSSES;
 
 		String input = args[0].toLowerCase();
-
-		return availableBoss.stream()
+		return AVAILABLE_BOSSES.stream()
 				.filter(boss -> boss.toLowerCase().startsWith(input))
 				.collect(Collectors.toList());
 	}

--- a/src/main/java/ourstory/commands/CancelDrop.java
+++ b/src/main/java/ourstory/commands/CancelDrop.java
@@ -1,29 +1,52 @@
 package ourstory.commands;
 
-import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
-import org.bukkit.plugin.Plugin;
 import io.papermc.paper.command.brigadier.BasicCommand;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import ourstory.Main;
+import ourstory.utils.Permissions;
 
 public class CancelDrop implements BasicCommand {
 
-	private final Plugin plugin = Bukkit.getPluginManager().getPlugin("OurStory");
-	private final NamespacedKey ItemIsLocked = new NamespacedKey(plugin, "locked");
+	private NamespacedKey itemIsLockedKey() {
+		return new NamespacedKey(Main.plugin, "locked");
+	}
 
 	@Override
 	public void execute(CommandSourceStack sender, String[] args) {
-		Player player = (Player) sender.getSender();
+		if (!Permissions.checkPermissions(sender.getSender(), "ourstory.itemlock"))
+			return;
+
+		if (!(sender.getSender() instanceof Player player)) {
+			sender.getSender().sendMessage("Only a player can run this command !");
+			return;
+		}
+
 		ItemStack item = player.getInventory().getItemInMainHand();
+		if (item.isEmpty()) {
+			player.sendMessage(Component.text("You must hold an item to lock or unlock it.").color(NamedTextColor.RED));
+			return;
+		}
+
 		ItemMeta meta = item.getItemMeta();
+		if (meta == null) {
+			player.sendMessage(Component.text("This item cannot be locked.").color(NamedTextColor.RED));
+			return;
+		}
 
-		boolean isLocked = item.getPersistentDataContainer().getOrDefault(ItemIsLocked, PersistentDataType.BOOLEAN, false);
-
-		meta.getPersistentDataContainer().set(ItemIsLocked, PersistentDataType.BOOLEAN, !isLocked);
+		NamespacedKey key = itemIsLockedKey();
+		boolean isLocked = meta.getPersistentDataContainer().getOrDefault(key, PersistentDataType.BOOLEAN, false);
+		meta.getPersistentDataContainer().set(key, PersistentDataType.BOOLEAN, !isLocked);
 		item.setItemMeta(meta);
+
+		player.sendMessage(Component.text(
+				isLocked ? "Item drop-lock removed." : "Item is now drop-locked.")
+				.color(isLocked ? NamedTextColor.YELLOW : NamedTextColor.GREEN));
 	}
 }

--- a/src/main/java/ourstory/commands/Cast.java
+++ b/src/main/java/ourstory/commands/Cast.java
@@ -2,78 +2,65 @@ package ourstory.commands;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import org.bukkit.Bukkit;
+import java.util.function.BiFunction;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
-import org.jetbrains.annotations.NotNull;
 import org.jspecify.annotations.NonNull;
 import io.papermc.paper.command.brigadier.BasicCommand;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
-import ourstory.spells.*;
+import ourstory.Main;
+import ourstory.spells.Annihilation;
+import ourstory.spells.GravityWell;
+import ourstory.spells.Spell;
 import ourstory.utils.Permissions;
+import org.bukkit.entity.Entity;
+import java.util.ArrayList;
 
 public class Cast implements BasicCommand {
 
-	public Map<String, Spell> skills;
-	private Plugin p = Bukkit.getPluginManager().getPlugin("OurStory");
-
-	static {
-		final Map<String, Spell> skills = Map.of(
-				"Annihilation", new Annihilation(null, null, 0),
-				"LaserMatrix", new LaserMatrix(null, null, 0),
-				"LaserExplosion", new LaserExplosion(null, null, 0),
-				"ArrowWall", new ArrowWall(null, null, 0));
-	}
-
+	private static final java.util.Map<String, BiFunction<Player, List<Entity>, Spell>> SPELLS = java.util.Map.of(
+			"Annihilation", (p, t) -> new Annihilation(p, t, 1),
+			"GravityWell", (p, t) -> new GravityWell(p, t, 1));
 
 	@Override
 	public void execute(CommandSourceStack sender, String[] args) {
 		if (!Permissions.checkPermissions(sender.getSender(), "ourstory.cast"))
 			return;
 
-		Player player = (Player) sender.getSender();
-
-		if (args.length == 0) {
-			player.sendMessage("You need to provide a skill name");
+		if (!(sender.getSender() instanceof Player player)) {
+			sender.getSender().sendMessage("Only a player can run this command !");
 			return;
 		}
 
-		Spell test = new Annihilation(player, player.getNearbyEntities(50, 50, 50), 1);
-		test.setup();
+		if (args.length == 0) {
+			player.sendMessage("You need to provide a spell name. Available: " + String.join(", ", SPELLS.keySet()));
+			return;
+		}
+
+		BiFunction<Player, List<Entity>, Spell> factory = SPELLS.get(args[0]);
+		if (factory == null) {
+			player.sendMessage("Unknown spell: " + args[0]);
+			return;
+		}
+
+		Spell spell = factory.apply(player, new ArrayList<>(player.getNearbyEntities(50, 50, 50)));
+		spell.setup();
 
 		new BukkitRunnable() {
 			@Override
 			public void run() {
-				if (test.shouldStop()) {
-					test.stop();
+				if (spell.shouldStop()) {
+					spell.stop();
 					cancel();
+					return;
 				}
-				test.tick();
+				spell.tick();
 			}
-		}.runTaskTimer(p, 0, 1);
-
-
-		// for (String s : args) {
-		// if (!skills.containsKey(s))
-		// continue;
-		// if (s.equalsIgnoreCase("Annihilation")) {
-		// new Annihilation(player, player.getNearbyEntities(50, 50, 50), 1);
-
-
-		// }
-
-		// // skills.get(s).cast(player, player.getNearbyEntities(50, 50, 50), 1);
-		// }
+		}.runTaskTimer(Main.plugin, 0, 1);
 	}
 
-	/*
-	 * /boss <bossname> <difficulty>
-	 */
 	@Override
 	public @NonNull Collection<String> suggest(@NonNull CommandSourceStack commandSourceStack, String[] args) {
-		// return skills.keySet();
-		return List.of("Annihilation");
+		return SPELLS.keySet();
 	}
 }

--- a/src/main/java/ourstory/commands/Count.java
+++ b/src/main/java/ourstory/commands/Count.java
@@ -1,8 +1,9 @@
 package ourstory.commands;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.ArrayList;
+import java.util.Locale;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -18,16 +19,15 @@ public class Count implements BasicCommand {
 		if (!Permissions.checkPermissions(sender.getSender(), "ourstory.count"))
 			return;
 
-		if (!(sender.getSender() instanceof Player)) {
+		if (!(sender.getSender() instanceof Player p)) {
 			sender.getSender().sendMessage("Only a player can run this command !");
 			return;
 		}
 
-		Player p = (Player) sender.getSender();
 		Material material = null;
 
 		if (args.length > 0) {
-			material = Material.getMaterial(args[0]);
+			material = Material.matchMaterial(args[0]);
 		} else {
 			ItemStack item = p.getInventory().getItemInMainHand();
 			if (!item.isEmpty())
@@ -35,7 +35,7 @@ public class Count implements BasicCommand {
 		}
 
 		if (material == null) {
-			sender.getSender().sendMessage(Component.text("You need to provide an item name !").color(NamedTextColor.RED));
+			sender.getSender().sendMessage(Component.text("You need to provide a valid item name !").color(NamedTextColor.RED));
 			return;
 		}
 
@@ -49,24 +49,24 @@ public class Count implements BasicCommand {
 
 	@Override
 	public Collection<String> suggest(CommandSourceStack commandSourceStack, String[] args) {
+		String prefix = args.length == 0 ? "" : args[0].toUpperCase(Locale.ROOT);
 		List<String> suggestions = new ArrayList<>();
-		for (Material material : Material.values())
-			if (material.toString().startsWith(args[0].toUpperCase()))
-				suggestions.add(material.toString());
+		for (Material material : Material.values()) {
+			String name = material.toString();
+			if (prefix.isEmpty() || name.startsWith(prefix))
+				suggestions.add(name);
+		}
 		return suggestions;
 	}
 
 	private static int countItems(Player player, Material material) {
 		int count = 0;
-
 		for (ItemStack item : player.getInventory().getContents()) {
 			if (item == null)
 				continue;
-
 			if (item.getType().equals(material))
 				count += item.getAmount();
 		}
-
 		return count;
 	}
 }

--- a/src/main/java/ourstory/commands/Dummy.java
+++ b/src/main/java/ourstory/commands/Dummy.java
@@ -7,31 +7,26 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import org.bukkit.metadata.FixedMetadataValue;
-import org.bukkit.plugin.Plugin;
-
 import io.papermc.paper.command.brigadier.BasicCommand;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import net.kyori.adventure.text.Component;
+import ourstory.Main;
 import ourstory.utils.Permissions;
 
 public class Dummy implements BasicCommand {
 
-	private Plugin p = Bukkit.getPluginManager().getPlugin("OurStory");
-
-	private final Map<String, String> DummyName = Map.of(
+	private static final Map<String, String> DUMMY_NAME = Map.of(
 			"Normal", "Classic",
 			"Undead", "Undead",
 			"Spider", "Crawling",
 			"Marin", "Aquatic");
 
-	private final Map<String, String> DummyTag = Map.of(
+	private static final Map<String, String> DUMMY_TAG = Map.of(
 			"Undead", "sensitive_smite",
 			"Spider", "sensitive_boa",
 			"Marin", "sensitive_impaling");
@@ -41,30 +36,25 @@ public class Dummy implements BasicCommand {
 		if (!Permissions.checkPermissions(sender.getSender(), "ourstory.dummy"))
 			return;
 
-		if (!(sender.getSender() instanceof Player)) {
+		if (!(sender.getSender() instanceof Player player)) {
 			sender.getSender().sendMessage("Only a player can run this command !");
 			return;
 		}
 
-		Player player = (Player) sender.getSender();
 		World w = player.getWorld();
-
 		ArmorStand dummy = (ArmorStand) w.spawnEntity(player.getLocation(), EntityType.ARMOR_STAND);
 
-		Set<String> baseName = new HashSet<String>();
-
-		for (String argus : args) {
-			if (DummyName.containsKey(argus))
-				baseName.add(DummyName.get(argus));
-			if (DummyTag.containsKey(argus))
-				dummy.setMetadata(DummyTag.get(argus), new FixedMetadataValue(p, true));
+		Set<String> baseName = new HashSet<>();
+		for (String arg : args) {
+			if (DUMMY_NAME.containsKey(arg))
+				baseName.add(DUMMY_NAME.get(arg));
+			if (DUMMY_TAG.containsKey(arg))
+				dummy.setMetadata(DUMMY_TAG.get(arg), new FixedMetadataValue(Main.plugin, true));
 		}
 
 		if (baseName.isEmpty())
 			baseName.add("Classic");
 
-		// Don't let duplicate name be there and sort them like : Undead Crawling Aquatic Dummy. Moreover,
-		// remove Classic if another one is there
 		String finalName = new ArrayList<>(baseName).stream()
 				.filter(word -> !(word.equals("Classic") && baseName.size() > 1))
 				.sorted(Comparator.reverseOrder())
@@ -72,12 +62,11 @@ public class Dummy implements BasicCommand {
 
 		dummy.customName(Component.text(finalName + " Dummy"));
 		dummy.setCustomNameVisible(true);
-
-		dummy.setMetadata("isDummy", new FixedMetadataValue(p, true));
+		dummy.setMetadata("isDummy", new FixedMetadataValue(Main.plugin, true));
 	}
 
 	@Override
 	public Collection<String> suggest(CommandSourceStack commandSourceStack, String[] args) {
-		return DummyName.keySet();
+		return DUMMY_NAME.keySet();
 	}
 }

--- a/src/main/java/ourstory/commands/MobGoalCommand.java
+++ b/src/main/java/ourstory/commands/MobGoalCommand.java
@@ -7,16 +7,21 @@ import org.bukkit.entity.Mob;
 import org.bukkit.entity.Player;
 import io.papermc.paper.command.brigadier.BasicCommand;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
-import ourstory.bosses.HolyCow;
 import ourstory.bosses.Boss;
+import ourstory.bosses.HolyCow;
+import ourstory.utils.Permissions;
 
 public class MobGoalCommand implements BasicCommand {
 	@Override
 	public void execute(CommandSourceStack cmdSource, String[] args) {
-		if (!(cmdSource.getExecutor() instanceof Player)) {
+		if (!Permissions.checkPermissions(cmdSource.getSender(), "ourstory.goal"))
+			return;
+
+		if (!(cmdSource.getExecutor() instanceof Player sender)) {
+			cmdSource.getSender().sendMessage("Only a player can run this command !");
 			return;
 		}
-		Player sender = (Player) cmdSource.getExecutor();
+
 		Mob holyCowMob = (Mob) sender.getWorld().spawn(sender.getLocation(), Cow.class);
 		Boss boss = new HolyCow(holyCowMob, List.of(sender), 0);
 		boss.registerGoals(Bukkit.getServer().getMobGoals());

--- a/src/main/java/ourstory/events/onArrowRain.java
+++ b/src/main/java/ourstory/events/onArrowRain.java
@@ -1,9 +1,8 @@
 package ourstory.events;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
-
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
@@ -16,12 +15,12 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataType;
-import org.bukkit.plugin.Plugin;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.Vector;
-
+import ourstory.Main;
 import ourstory.utils.EnchantItem;
 
 /**
@@ -30,73 +29,103 @@ import ourstory.utils.EnchantItem;
  */
 public class onArrowRain implements Listener {
 
-	private final Plugin plugin = Bukkit.getPluginManager().getPlugin("OurStory");
-	private final NamespacedKey bowEnchantSaver = new NamespacedKey(plugin, "bowEnchantSaver");
-	private final NamespacedKey bowForceSaver = new NamespacedKey(plugin, "bowForceSaver");
-	private final HashMap<UUID, Integer> currentActiveArrows = new HashMap<UUID, Integer>();
-	private final int maxGeneratingArrowsPerPlayer = 10;
-	private final int arrowDespawnRate = 1200;
-	private final int arrowLifeTime = 40;
+	private static final int MAX_GENERATING_ARROWS_PER_PLAYER = 10;
+	private static final int ARROW_DESPAWN_RATE = 1200;
+	private static final int ARROW_LIFE_TIME = 40;
+
+	private final Map<UUID, Integer> currentActiveArrows = new HashMap<>();
+
+	private NamespacedKey bowEnchantSaver() {
+		return new NamespacedKey(Main.plugin, "bowEnchantSaver");
+	}
+
+	private NamespacedKey bowForceSaver() {
+		return new NamespacedKey(Main.plugin, "bowForceSaver");
+	}
 
 	@EventHandler
 	public void onLaunch(EntityShootBowEvent e) {
 		ItemStack bow = e.getBow();
-		if (bow.getType() != Material.BOW)
+		if (bow == null || bow.getType() != Material.BOW)
 			return;
-		if (EnchantItem.getEnchantAmount(bow, "arrow_rain") == 0)
+		int enchantAmount = EnchantItem.getEnchantAmount(bow, "arrow_rain");
+		if (enchantAmount == 0)
 			return;
 
-		e.getProjectile().getPersistentDataContainer().set(bowEnchantSaver, PersistentDataType.INTEGER, EnchantItem.getEnchantAmount(e.getBow(), "arrow_rain"));
-		e.getProjectile().getPersistentDataContainer().set(bowForceSaver, PersistentDataType.FLOAT, e.getForce());
+		e.getProjectile().getPersistentDataContainer().set(bowEnchantSaver(), PersistentDataType.INTEGER, enchantAmount);
+		e.getProjectile().getPersistentDataContainer().set(bowForceSaver(), PersistentDataType.FLOAT, e.getForce());
 	}
 
 	@EventHandler
 	public void arrowRain(ProjectileHitEvent event) {
-		if (!event.getEntity().getPersistentDataContainer().has(bowEnchantSaver, PersistentDataType.INTEGER))
+		if (!(event.getEntity() instanceof Arrow arrowOrigin))
+			return;
+		if (!arrowOrigin.getPersistentDataContainer().has(bowEnchantSaver(), PersistentDataType.INTEGER))
 			return;
 
-		Arrow arrowOrigin = (Arrow) event.getEntity();
-		LivingEntity player = (LivingEntity) arrowOrigin.getShooter();
-		UUID playerId = player.getUniqueId();
+		if (!(arrowOrigin.getShooter() instanceof LivingEntity shooter))
+			return;
+		UUID shooterId = shooter.getUniqueId();
 
-		int enchantLevel = arrowOrigin.getPersistentDataContainer().get(bowEnchantSaver, PersistentDataType.INTEGER);
-		float force = arrowOrigin.getPersistentDataContainer().get(bowForceSaver, PersistentDataType.FLOAT);
-
-		Entity hitty = event.getHitEntity();
-		if (hitty == null)
+		Integer enchantLevel = arrowOrigin.getPersistentDataContainer().get(bowEnchantSaver(), PersistentDataType.INTEGER);
+		Float force = arrowOrigin.getPersistentDataContainer().get(bowForceSaver(), PersistentDataType.FLOAT);
+		if (enchantLevel == null || force == null)
 			return;
 
-		if (!currentActiveArrows.containsKey(playerId))
-			currentActiveArrows.put(playerId, 0);
-		if (currentActiveArrows.get(playerId) >= maxGeneratingArrowsPerPlayer)
+		Entity hitEntity = event.getHitEntity();
+		if (hitEntity == null)
 			return;
-		currentActiveArrows.replace(playerId, currentActiveArrows.get(playerId) + 1);
+
+		Location anchor = hitEntity.getLocation();
+
+		int active = currentActiveArrows.getOrDefault(shooterId, 0);
+		if (active >= MAX_GENERATING_ARROWS_PER_PLAYER)
+			return;
+		currentActiveArrows.put(shooterId, active + 1);
+
+		final int levels = enchantLevel;
+		final float launchForce = force;
 		new BukkitRunnable() {
 			int counter = 0;
 
 			@Override
 			public void run() {
-				if (counter >= enchantLevel) {
-					currentActiveArrows.replace(playerId, currentActiveArrows.get(playerId) - 1);
+				if (counter >= levels || !shooter.isValid()) {
+					Integer remaining = currentActiveArrows.get(shooterId);
+					if (remaining != null) {
+						int newValue = remaining - 1;
+						if (newValue <= 0)
+							currentActiveArrows.remove(shooterId);
+						else
+							currentActiveArrows.put(shooterId, newValue);
+					}
 					this.cancel();
 					return;
 				}
-				Location entityLoc = event.getHitEntity().getLocation().add(0, 8, 0);
-				while (!entityLoc.getBlock().isPassable())
+
+				Location entityLoc = anchor.clone().add(0, 8, 0);
+				int safety = 0;
+				while (!entityLoc.getBlock().isPassable() && safety++ < 64)
 					entityLoc.add(0, 1, 0);
-				Arrow arrow = player.getWorld().spawnArrow(entityLoc, new Vector(0, -1, 0), force, 0);
-				arrow.setBasePotionType((arrowOrigin).getBasePotionType());
-				arrow.setLifetimeTicks(arrowDespawnRate - arrowLifeTime);
-				arrow.setShooter(player);
-				arrow.setDamage((arrowOrigin).getDamage());
-				arrow.setWeapon((arrowOrigin).getWeapon());
-				arrow.setCritical((arrowOrigin).isCritical());
+
+				Arrow arrow = shooter.getWorld().spawnArrow(entityLoc, new Vector(0, -1, 0), launchForce, 0);
+				arrow.setBasePotionType(arrowOrigin.getBasePotionType());
+				arrow.setLifetimeTicks(ARROW_DESPAWN_RATE - ARROW_LIFE_TIME);
+				arrow.setShooter(shooter);
+				arrow.setDamage(arrowOrigin.getDamage());
+				arrow.setWeapon(arrowOrigin.getWeapon());
+				arrow.setCritical(arrowOrigin.isCritical());
 				arrow.setHitSound(Sound.BLOCK_END_PORTAL_FRAME_FILL);
 				arrow.setGlowing(true);
 				arrow.setPickupStatus(PickupStatus.DISALLOWED);
 				arrow.setPierceLevel(127);
 				counter++;
 			}
-		}.runTaskTimer(plugin, 20, 20);
+		}.runTaskTimer(Main.plugin, 20, 20);
+	}
+
+	@EventHandler
+	public void onQuit(PlayerQuitEvent event) {
+		currentActiveArrows.remove(event.getPlayer().getUniqueId());
 	}
 }

--- a/src/main/java/ourstory/events/onBossDeath.java
+++ b/src/main/java/ourstory/events/onBossDeath.java
@@ -9,12 +9,15 @@ import ourstory.Main;
 public class onBossDeath implements Listener {
 	@EventHandler
 	public void bossDeath(EntityDeathEvent entity) {
-		// Cancel if not player
+		if (Main.runningInstance == null)
+			return;
+
 		if (!(entity.getEntity().getKiller() instanceof Player))
 			return;
 
-		// Call onHit method for boss monsters
-		if (!entity.getEntity().getMetadata("isBoss").isEmpty())
-			Main.runningInstance.boss.onDeath(entity);
+		if (entity.getEntity().getMetadata("isBoss").isEmpty())
+			return;
+
+		Main.runningInstance.boss.onDeath(entity);
 	}
 }

--- a/src/main/java/ourstory/events/onBossHit.java
+++ b/src/main/java/ourstory/events/onBossHit.java
@@ -9,12 +9,15 @@ import ourstory.Main;
 public class onBossHit implements Listener {
 	@EventHandler
 	public void bossHit(EntityDamageByEntityEvent entity) {
-		// Cancel if not player
+		if (Main.runningInstance == null)
+			return;
+
 		if (!(entity.getDamager() instanceof Player))
 			return;
 
-		// Call onHit method for boss monsters
-		if (!entity.getEntity().getMetadata("isBoss").isEmpty())
-			Main.runningInstance.boss.onHit(entity);
+		if (entity.getEntity().getMetadata("isBoss").isEmpty())
+			return;
+
+		Main.runningInstance.boss.onHit(entity);
 	}
 }

--- a/src/main/java/ourstory/events/onBreakVeine.java
+++ b/src/main/java/ourstory/events/onBreakVeine.java
@@ -1,16 +1,18 @@
 package ourstory.events;
 
-import org.bukkit.event.EventHandler;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
 import ourstory.utils.EnchantItem;
-import org.bukkit.Material;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import org.bukkit.entity.Player;
 
 public class onBreakVeine implements Listener {
 
@@ -29,46 +31,44 @@ public class onBreakVeine implements Listener {
 			Material.DEEPSLATE_DIAMOND_ORE,
 			Material.DEEPSLATE_EMERALD_ORE);
 
-
-	private static void getBlockList(Block block, Set<Block> visited, int maxBlocks, Material block_type) {
-		if (visited.size() >= maxBlocks)
-			return;
-
-		if (block.getType() != block_type)
-			return;
-
-		if (!visited.add(block))
-			return;
-
-		// voisins (6 directions)
-		for (Block relative : new Block[] {
-				block.getRelative(1, 0, 0),
-				block.getRelative(-1, 0, 0),
-				block.getRelative(0, 1, 0),
-				block.getRelative(0, -1, 0),
-				block.getRelative(0, 0, 1),
-				block.getRelative(0, 0, -1)
-		}) {
-			getBlockList(relative, visited, maxBlocks, block_type);
-		}
-	}
-
 	@EventHandler
-	public void BreakVeine(BlockBreakEvent event) {
-		Player player = event.getPlayer();
-		ItemStack item = player.getInventory().getItemInMainHand();
-		int totalVeineMinerLevel = EnchantItem.getEnchantAmount(item, "veine_miner");
-
+	public void breakVeine(BlockBreakEvent event) {
 		if (!ALLOWED_BLOCKS.contains(event.getBlock().getType()))
 			return;
 
+		Player player = event.getPlayer();
+		ItemStack item = player.getInventory().getItemInMainHand();
 		if (!item.getType().name().endsWith("_PICKAXE"))
 			return;
 
-		Set<Block> block_list = new HashSet<>();
-		getBlockList(event.getBlock(), block_list, totalVeineMinerLevel * 2 + 1, event.getBlock().getType());
+		int veinMinerLevel = EnchantItem.getEnchantAmount(item, "veine_miner");
+		if (veinMinerLevel <= 0)
+			return;
 
-		for (Block b : block_list)
+		int maxExtra = veinMinerLevel * 2;
+		Set<Block> visited = new HashSet<>();
+		visited.add(event.getBlock());
+
+		Deque<Block> queue = new ArrayDeque<>();
+		queue.add(event.getBlock());
+		Material target = event.getBlock().getType();
+
+		while (!queue.isEmpty() && visited.size() - 1 < maxExtra) {
+			Block current = queue.removeFirst();
+			for (int[] delta : new int[][]{{1,0,0},{-1,0,0},{0,1,0},{0,-1,0},{0,0,1},{0,0,-1}}) {
+				if (visited.size() - 1 >= maxExtra)
+					break;
+				Block neighbor = current.getRelative(delta[0], delta[1], delta[2]);
+				if (neighbor.getType() != target)
+					continue;
+				if (!visited.add(neighbor))
+					continue;
+				queue.add(neighbor);
+			}
+		}
+
+		visited.remove(event.getBlock());
+		for (Block b : visited)
 			b.breakNaturally(item);
 	}
 }

--- a/src/main/java/ourstory/events/onDisplayItem.java
+++ b/src/main/java/ourstory/events/onDisplayItem.java
@@ -1,48 +1,46 @@
 package ourstory.events;
 
-import java.util.Arrays;
 import java.util.List;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import io.papermc.paper.event.player.AsyncChatEvent;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
-import net.kyori.adventure.text.event.HoverEvent;
-import net.kyori.adventure.text.event.HoverEvent.ShowItem;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 
 public class onDisplayItem implements Listener {
 
-	private List<String> triggerWords = Arrays.asList("*", "@", "[item]");
+	private static final List<String> TRIGGER_WORDS = List.of("*", "@", "[item]");
 
 	@EventHandler
 	public void displayItemInChat(AsyncChatEvent event) {
 		Component message = event.originalMessage();
 		String content = PlainTextComponentSerializer.plainText().serialize(message);
 
-		if (!triggerWords.contains(content))
+		if (!TRIGGER_WORDS.contains(content))
 			return;
 
 		Player player = event.getPlayer();
 		ItemStack mainHandItem = player.getInventory().getItemInMainHand();
-		HoverEvent<ShowItem> he = mainHandItem.asHoverEvent();
-
-		if (mainHandItem == null || mainHandItem.getType().isAir())
+		if (mainHandItem.isEmpty())
 			return;
 
-		Component itemName = mainHandItem.getItemMeta().hasDisplayName()
-				? mainHandItem.getItemMeta().displayName()
+		ItemMeta meta = mainHandItem.getItemMeta();
+		Component itemName = (meta != null && meta.hasDisplayName())
+				? meta.displayName()
 				: Component.text(mainHandItem.getType().name());
 
-		TextComponent result = Component.text(player.getName() + " shared ").append(itemName).hoverEvent(he);
+		TextComponent result = Component.text(player.getName() + " shared ")
+				.append(itemName)
+				.hoverEvent(mainHandItem.asHoverEvent());
 
 		for (Player p : Bukkit.getOnlinePlayers())
 			p.sendMessage(result);
 
-		// Cancel the message containing the trigger word
 		event.setCancelled(true);
 	}
 }

--- a/src/main/java/ourstory/events/onEntityDeath.java
+++ b/src/main/java/ourstory/events/onEntityDeath.java
@@ -10,16 +10,14 @@ import ourstory.utils.EnchantItem;
 public class onEntityDeath implements Listener {
 	@EventHandler
 	public void entityDeath(EntityDeathEvent entity) {
-		// Cancel if not player
-		if (!(entity.getEntity().getKiller() instanceof Player))
+		if (!(entity.getEntity().getKiller() instanceof Player killer))
 			return;
 
-		Player killer = (Player) entity.getEntity().getKiller();
-
-		// Compute Leech enchant
 		ItemStack weapon = killer.getInventory().getItemInMainHand();
 		int totalLeechLevel = EnchantItem.getEnchantAmount(weapon, "leech");
+		if (totalLeechLevel <= 0)
+			return;
 
-		killer.heal(totalLeechLevel / 2);
+		killer.heal(totalLeechLevel / 2.0);
 	}
 }

--- a/src/main/java/ourstory/events/onItemDrop.java
+++ b/src/main/java/ourstory/events/onItemDrop.java
@@ -1,37 +1,39 @@
 package ourstory.events;
 
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
-import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerDropItemEvent;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
-import org.bukkit.plugin.Plugin;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
-
-/**
- *
- * @author NaNI7823
- */
+import ourstory.Main;
 
 public class onItemDrop implements Listener {
 
-	private final Plugin plugin = Bukkit.getPluginManager().getPlugin("OurStory");
-	private final NamespacedKey ItemIsLocked = new NamespacedKey(plugin, "locked");
+	private NamespacedKey itemIsLockedKey() {
+		return new NamespacedKey(Main.plugin, "locked");
+	}
 
 	@EventHandler
 	public void dropItem(PlayerDropItemEvent event) {
 		Player player = event.getPlayer();
 		Item item = event.getItemDrop();
 
-		boolean isLocked = item.getItemStack().getItemMeta().getPersistentDataContainer().getOrDefault(ItemIsLocked, PersistentDataType.BOOLEAN, false);
+		ItemMeta meta = item.getItemStack().getItemMeta();
+		if (meta == null)
+			return;
 
-		if (isLocked) {
-			event.setCancelled(true);
-			player.sendActionBar(Component.text("You can't drop : " + event.getItemDrop().getName() + ", you've locked it !").color(NamedTextColor.YELLOW));
-		}
+		boolean isLocked = meta.getPersistentDataContainer()
+				.getOrDefault(itemIsLockedKey(), PersistentDataType.BOOLEAN, false);
+
+		if (!isLocked)
+			return;
+
+		event.setCancelled(true);
+		player.sendActionBar(Component.text("You can't drop : " + item.getName() + ", you've locked it !").color(NamedTextColor.YELLOW));
 	}
 }

--- a/src/main/java/ourstory/events/onPhoenixDeath.java
+++ b/src/main/java/ourstory/events/onPhoenixDeath.java
@@ -2,58 +2,66 @@ package ourstory.events;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Random;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.plugin.Plugin;
 import org.bukkit.potion.PotionEffect;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import ourstory.Main;
 import ourstory.utils.EnchantItem;
 
 public class onPhoenixDeath implements Listener {
 
-	private Plugin p = Bukkit.getPluginManager().getPlugin("OurStory");
-	private final HashMap<UUID, List<PotionEffect>> savedEffects = new HashMap<>();
+	private final Map<UUID, List<PotionEffect>> savedEffects = new HashMap<>();
 
 	@EventHandler
 	public void phoenixDeath(PlayerDeathEvent event) {
 		Player player = event.getPlayer();
-		Random random = new Random();
 
 		ItemStack[] armorContents = player.getInventory().getArmorContents();
 		int totalPhoenixLevel = 0;
-
 		for (ItemStack armor : armorContents)
 			totalPhoenixLevel += EnchantItem.getEnchantAmount(armor, "phoenix");
 
-		if (random.nextInt(0, 101) < (totalPhoenixLevel * 2.5)) {
-			player.sendMessage(Component.text("You got blessed by the Phoenix enchant ! Your inventory and effects have been safeguarded !").color(NamedTextColor.GREEN));
-			event.setKeepInventory(true);
-			event.setKeepLevel(false);
-			event.setDroppedExp(0);
-			event.getDrops().clear();
-			savedEffects.put(player.getUniqueId(), List.copyOf(player.getActivePotionEffects()));
-		}
+		if (totalPhoenixLevel <= 0)
+			return;
+
+		double roll = ThreadLocalRandom.current().nextDouble(0, 100);
+		if (roll >= totalPhoenixLevel * 2.5)
+			return;
+
+		player.sendMessage(Component.text("You got blessed by the Phoenix enchant ! Your inventory and effects have been safeguarded !").color(NamedTextColor.GREEN));
+		event.setKeepInventory(true);
+		event.setKeepLevel(false);
+		event.setDroppedExp(0);
+		event.getDrops().clear();
+		savedEffects.put(player.getUniqueId(), List.copyOf(player.getActivePotionEffects()));
 	}
 
 	@EventHandler
 	public void phoenixRespawn(PlayerRespawnEvent event) {
 		Player player = event.getPlayer();
 		List<PotionEffect> effects = savedEffects.remove(player.getUniqueId());
-
 		if (effects == null)
 			return;
 
-		Bukkit.getScheduler().runTaskLater(p, () -> {
+		Bukkit.getScheduler().runTaskLater(Main.plugin, () -> {
 			for (PotionEffect effect : effects)
 				player.addPotionEffect(effect);
 		}, 20);
+	}
+
+	@EventHandler
+	public void onQuit(PlayerQuitEvent event) {
+		savedEffects.remove(event.getPlayer().getUniqueId());
 	}
 }

--- a/src/main/java/ourstory/events/onPlayerInteract.java
+++ b/src/main/java/ourstory/events/onPlayerInteract.java
@@ -1,6 +1,7 @@
 package ourstory.events;
 
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
@@ -12,11 +13,14 @@ public class onPlayerInteract implements Listener {
 	 */
 	@EventHandler
 	public void cancelPlayerJumpOnFarmland(PlayerInteractEvent e) {
-		if (e == null)
+		if (e.getAction() != Action.PHYSICAL)
 			return;
 
-		// Disable jumping on farmlands
-		if (e.getAction() == Action.PHYSICAL && e.getClickedBlock().getType().equals(Material.FARMLAND))
+		Block clicked = e.getClickedBlock();
+		if (clicked == null)
+			return;
+
+		if (clicked.getType() == Material.FARMLAND)
 			e.setCancelled(true);
 	}
 }

--- a/src/main/java/ourstory/events/onPlayerSit.java
+++ b/src/main/java/ourstory/events/onPlayerSit.java
@@ -20,38 +20,34 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.material.Directional;
 import org.bukkit.metadata.FixedMetadataValue;
-import org.bukkit.plugin.Plugin;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import ourstory.Main;
 
 public class onPlayerSit implements Listener {
 
-	private static String CHAIR_ENTITY_TAG = "chair";
-	private Plugin p = Bukkit.getPluginManager().getPlugin("OurStory");
+	private static final String CHAIR_ENTITY_TAG = "chair";
 
-	@EventHandler()
+	@EventHandler
 	public void playerSit(PlayerInteractEvent event) {
 		EquipmentSlot hand = event.getHand();
-
-		if (hand == null || !hand.equals(EquipmentSlot.HAND))
+		if (hand == null || hand != EquipmentSlot.HAND)
 			return;
-		if (!event.getAction().equals(Action.RIGHT_CLICK_BLOCK))
+		if (event.getAction() != Action.RIGHT_CLICK_BLOCK)
 			return;
 
 		Player player = event.getPlayer();
 		Block block = event.getClickedBlock();
+		if (block == null)
+			return;
+		if (player.getInventory().getItemInMainHand().getType() != Material.AIR)
+			return;
+		if (player.isSneaking() || player.isInsideVehicle())
+			return;
+
 		BlockData blockData = block.getBlockData();
 		Location pigLocation = pigLocationForBlock(block, player);
-
-		if (!player.getInventory().getItemInMainHand().getType().equals(Material.AIR))
-			return;
-		if (!isValidChairBlock(blockData, pigLocation))
-			return;
-		if (player.isSneaking())
-			return;
-		if (!player.getInventory().getItemInMainHand().getType().equals(Material.AIR))
-			return;
-		if (player.isInsideVehicle())
+		if (!isValidChairBlock(blockData))
 			return;
 
 		event.setCancelled(true);
@@ -61,29 +57,21 @@ public class onPlayerSit implements Listener {
 	}
 
 	private void configurePig(Pig pig) {
-		// movement speed to 0 to block carrot on a stick item effect
 		pig.getAttribute(Attribute.MOVEMENT_SPEED).setBaseValue(0);
 		pig.setSaddle(true);
 		pig.setInvulnerable(true);
 		pig.setGravity(false);
 		pig.setSilent(true);
-		pig.setMetadata(CHAIR_ENTITY_TAG, new FixedMetadataValue(p, true));
+		pig.setMetadata(CHAIR_ENTITY_TAG, new FixedMetadataValue(Main.plugin, true));
 		pig.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, 9999999, 0, false, false));
 		pig.setAI(false);
 	}
 
-	private boolean isValidChairBlock(BlockData block, Location pigLocation) {
-		if (block instanceof Stairs) {
-			Bisected bisected = (Bisected) block;
-			if (bisected.getHalf().equals(Bisected.Half.BOTTOM))
-				return true;
-		}
-		if (block instanceof Slab) {
-			Slab slab = (Slab) block;
-			if (slab.getType().equals(Slab.Type.BOTTOM))
-				return true;
-		}
-
+	private boolean isValidChairBlock(BlockData block) {
+		if (block instanceof Stairs stairs)
+			return stairs.getHalf() == Bisected.Half.BOTTOM;
+		if (block instanceof Slab slab)
+			return slab.getType() == Slab.Type.BOTTOM;
 		return false;
 	}
 
@@ -94,42 +82,32 @@ public class onPlayerSit implements Listener {
 		loc.setY(loc.getY() - 0.45);
 		loc.setZ(loc.getZ() + 0.5);
 
-		if (blockData instanceof Directional) {
-			BlockFace facing = ((Directional) blockData).getFacing();
+		if (blockData instanceof Directional directional) {
+			BlockFace facing = directional.getFacing();
 			switch (facing) {
-				case SOUTH:
-					loc.setYaw(180);
-					break;
-				case WEST:
-					loc.setYaw(270);
-					break;
-				case EAST:
-					loc.setYaw(90);
-					break;
-				case NORTH:
-					loc.setYaw(0);
-					break;
-				default:
+				case SOUTH -> loc.setYaw(180);
+				case WEST -> loc.setYaw(270);
+				case EAST -> loc.setYaw(90);
+				case NORTH -> loc.setYaw(0);
+				default -> { /* leave default yaw */ }
 			}
 		} else {
 			loc.setYaw(player.getLocation().getYaw() + 180);
 		}
 
-		if (blockData instanceof Stairs) {
-			Stairs.Shape shape = ((Stairs) blockData).getShape();
-			if (shape == Stairs.Shape.INNER_RIGHT || shape == Stairs.Shape.OUTER_RIGHT) {
+		if (blockData instanceof Stairs stairs) {
+			Stairs.Shape shape = stairs.getShape();
+			if (shape == Stairs.Shape.INNER_RIGHT || shape == Stairs.Shape.OUTER_RIGHT)
 				loc.setYaw(loc.getYaw() + 45);
-			} else if (shape == Stairs.Shape.INNER_LEFT || shape == Stairs.Shape.OUTER_LEFT) {
+			else if (shape == Stairs.Shape.INNER_LEFT || shape == Stairs.Shape.OUTER_LEFT)
 				loc.setYaw(loc.getYaw() - 45);
-			}
 		}
 		return loc;
 	}
 
 	@EventHandler
 	public void onDismount(EntityDismountEvent e) {
-		if (e.getDismounted().hasMetadata(CHAIR_ENTITY_TAG)) {
-			Bukkit.getScheduler().runTaskLater(p, () -> e.getDismounted().remove(), 1L);
-		}
+		if (e.getDismounted().hasMetadata(CHAIR_ENTITY_TAG))
+			Bukkit.getScheduler().runTaskLater(Main.plugin, () -> e.getDismounted().remove(), 1L);
 	}
 }

--- a/src/main/java/ourstory/events/onPlayerTips.java
+++ b/src/main/java/ourstory/events/onPlayerTips.java
@@ -1,23 +1,33 @@
 package ourstory.events;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import org.bukkit.Bukkit;
 import org.json.JSONArray;
+import org.json.JSONException;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import ourstory.Main;
 
 public class onPlayerTips {
+	private onPlayerTips() {
+		throw new IllegalStateException("Utility class");
+	}
+
 	public static void playerTips() {
-		// Skip event if no one is online
-		if (Bukkit.getOnlinePlayers().size() == 0)
+		if (Bukkit.getOnlinePlayers().isEmpty())
 			return;
 
-		JSONArray tipsMessages = Main.messages.getJSONArray("tips");
+		JSONArray tipsMessages;
+		try {
+			tipsMessages = Main.messages.getJSONArray("tips");
+		} catch (JSONException e) {
+			return;
+		}
 
-		Random rng = new Random();
-		int randomIndex = rng.nextInt(tipsMessages.length());
+		if (tipsMessages.length() == 0)
+			return;
 
+		int randomIndex = ThreadLocalRandom.current().nextInt(tipsMessages.length());
 		Bukkit.broadcast(Component.text("[Tip] " + tipsMessages.getString(randomIndex)).color(NamedTextColor.GREEN));
 	}
 }

--- a/src/main/java/ourstory/events/onReachEquip.java
+++ b/src/main/java/ourstory/events/onReachEquip.java
@@ -1,16 +1,15 @@
 package ourstory.events;
 
-import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.inventory.ItemStack;
-
 import com.destroystokyo.paper.event.player.PlayerArmorChangeEvent;
-
+import ourstory.Main;
 import ourstory.utils.EnchantItem;
 
 /**
@@ -18,26 +17,34 @@ import ourstory.utils.EnchantItem;
  * @author aurel
  */
 public class onReachEquip implements Listener {
+
+	private static final int MAX_REACH_LEVEL = 4;
+
 	@EventHandler
 	public void onPlayerChangeArmor(PlayerArmorChangeEvent event) {
 		Player player = event.getPlayer();
 		int totalReachLevels = 0;
-		ItemStack[] armorContents = player.getInventory().getArmorContents();
-
-		for (ItemStack armor : armorContents)
+		for (ItemStack armor : player.getInventory().getArmorContents())
 			totalReachLevels += EnchantItem.getEnchantAmount(armor, "reach");
 
-		if (totalReachLevels > 4)
-			totalReachLevels = 4;
+		if (totalReachLevels > MAX_REACH_LEVEL)
+			totalReachLevels = MAX_REACH_LEVEL;
+
 		applyReachModifier(player, totalReachLevels);
 	}
 
 	private void applyReachModifier(Player player, int reachLevel) {
-		NamespacedKey ReachKey = new NamespacedKey(Bukkit.getPluginManager().getPlugin("OurStory"), "reach_bonus");
-		if (player.getAttribute(Attribute.BLOCK_INTERACTION_RANGE) != null)
-			player.getAttribute(Attribute.BLOCK_INTERACTION_RANGE).removeModifier(ReachKey);
+		AttributeInstance attribute = player.getAttribute(Attribute.BLOCK_INTERACTION_RANGE);
+		if (attribute == null)
+			return;
 
-		AttributeModifier buff = new AttributeModifier(ReachKey, reachLevel, AttributeModifier.Operation.ADD_NUMBER);
-		player.getAttribute(Attribute.BLOCK_INTERACTION_RANGE).addModifier(buff);
+		NamespacedKey reachKey = new NamespacedKey(Main.plugin, "reach_bonus");
+		attribute.removeModifier(reachKey);
+
+		if (reachLevel <= 0)
+			return;
+
+		AttributeModifier buff = new AttributeModifier(reachKey, reachLevel, AttributeModifier.Operation.ADD_NUMBER);
+		attribute.addModifier(buff);
 	}
 }

--- a/src/main/java/ourstory/events/onSpawnerDrop.java
+++ b/src/main/java/ourstory/events/onSpawnerDrop.java
@@ -18,41 +18,40 @@ import ourstory.utils.EnchantItem;
 import ourstory.utils.MonsterUtils;
 
 public class onSpawnerDrop implements Listener {
-	/*
-	 * Event that computes if a spawner should drop
-	 */
+
+	private static final int[] RATES = {
+			1000000, 975000, 900000, 825000, 750000,
+			600000, 500000, 350000, 200000, 100000, 10000
+	};
+
 	@EventHandler
 	public void spawnerDrop(EntityDeathEvent entity) {
-		// Cancel if not player
-		if (!(entity.getEntity().getKiller() instanceof Player))
+		if (!(entity.getEntity().getKiller() instanceof Player killer))
 			return;
 
-		Player killer = (Player) entity.getEntity().getKiller();
-
-		// Compute looting enchant
 		ItemStack weapon = killer.getInventory().getItemInMainHand();
 		int totalLootingLevel = EnchantItem.getEnchantAmount(weapon, "looting");
-
-		int rates[] = {1000000, 975000, 900000, 825000, 750000, 600000, 500000, 350000, 200000, 100000, 10000};
+		int index = Math.min(Math.max(totalLootingLevel, 0), RATES.length - 1);
 
 		Random rng = new Random();
+		if (rng.nextInt(RATES[index]) != 1)
+			return;
 
-		if (rng.nextInt(rates[totalLootingLevel]) == 1) {
-			EntityType entityType = entity.getEntity().getType();
-			Material spawnEgg = MonsterUtils.getMonsterEgg(entityType);
+		EntityType entityType = entity.getEntity().getType();
+		Material spawnEgg = MonsterUtils.getMonsterEgg(entityType);
 
-			ItemStack eggItem = new ItemStack(spawnEgg, 1);
-			ItemMeta eggMeta = eggItem.getItemMeta();
-
+		ItemStack eggItem = new ItemStack(spawnEgg, 1);
+		ItemMeta eggMeta = eggItem.getItemMeta();
+		if (eggMeta != null) {
 			eggMeta.itemName(Component.text("Mythical " + spawnEgg.name()).color(NamedTextColor.DARK_PURPLE).decorate(TextDecoration.BOLD));
 			eggItem.setItemMeta(eggMeta);
-
-			entity.getDrops().add(eggItem);
-
-			Bukkit.broadcast(Component.text("Player " + killer.getName() + " just dropped a Mythical " + spawnEgg.toString() + " !").color(NamedTextColor.DARK_PURPLE));
-			Bukkit.broadcast(Component.text("Congratulation on such an amazing achievement !").color(NamedTextColor.DARK_PURPLE));
-
-			killer.playSound(killer.getLocation(), Sound.ENTITY_ENDER_DRAGON_DEATH, 1000, 1);
 		}
+
+		entity.getDrops().add(eggItem);
+
+		Bukkit.broadcast(Component.text("Player " + killer.getName() + " just dropped a Mythical " + spawnEgg.toString() + " !").color(NamedTextColor.DARK_PURPLE));
+		Bukkit.broadcast(Component.text("Congratulation on such an amazing achievement !").color(NamedTextColor.DARK_PURPLE));
+
+		killer.playSound(killer.getLocation(), Sound.ENTITY_ENDER_DRAGON_DEATH, 1000, 1);
 	}
 }

--- a/src/main/java/ourstory/events/onTridentHit.java
+++ b/src/main/java/ourstory/events/onTridentHit.java
@@ -1,6 +1,5 @@
 package ourstory.events;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Sound;
@@ -16,13 +15,18 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
+import ourstory.Main;
 
 /*
  * Credit to @aurel
  */
 public class onTridentHit implements Listener {
-	private final NamespacedKey wipeTrident = new NamespacedKey(Bukkit.getPluginManager().getPlugin("OurStory"), "wipeTrident");
+	private NamespacedKey wipeTridentKey() {
+		return new NamespacedKey(Main.plugin, "wipeTrident");
+	}
 
 	@EventHandler
 	public void onLaunch(ProjectileLaunchEvent e) {
@@ -31,19 +35,17 @@ public class onTridentHit implements Listener {
 		if (trident.getType() != EntityType.TRIDENT)
 			return;
 
-		if (!(trident.getShooter() instanceof Player))
+		if (!(trident.getShooter() instanceof Player p))
 			return;
 
-		Player p = (Player) trident.getShooter();
-
-		if (!p.getInventory().getItemInMainHand().getItemMeta().hasEnchant(Enchantment.CHANNELING))
+		ItemStack mainHand = p.getInventory().getItemInMainHand();
+		ItemMeta meta = mainHand.getItemMeta();
+		if (meta == null || !meta.hasEnchant(Enchantment.CHANNELING))
 			return;
-		trident.getPersistentDataContainer().set(wipeTrident, PersistentDataType.INTEGER, 1);
+
+		trident.getPersistentDataContainer().set(wipeTridentKey(), PersistentDataType.INTEGER, 1);
 	}
 
-	/*
-	 * Detects when a trident hits a bloc
-	 */
 	@EventHandler
 	public void onTridentHitBlock(ProjectileHitEvent event) {
 		Projectile trident = event.getEntity();
@@ -51,15 +53,15 @@ public class onTridentHit implements Listener {
 		if (!(trident instanceof Trident))
 			return;
 
-		if (!trident.getPersistentDataContainer().has(wipeTrident, PersistentDataType.INTEGER))
+		if (!trident.getPersistentDataContainer().has(wipeTridentKey(), PersistentDataType.INTEGER))
 			return;
 
 		Block hitBlock = event.getHitBlock();
-
 		if (hitBlock == null)
 			return;
 
-		Player player = (Player) trident.getShooter();
+		if (!(trident.getShooter() instanceof Player player))
+			return;
 
 		if (hitBlock.getType() == Material.LIGHTNING_ROD) {
 			player.getWorld().strikeLightning(event.getEntity().getLocation()).setCausingPlayer(player);
@@ -67,22 +69,21 @@ public class onTridentHit implements Listener {
 		}
 	}
 
-	/*
-	 * Triggers when a trident deals damage to an entity
-	 */
 	@EventHandler
 	public void onTridentHitEntity(EntityDamageByEntityEvent event) {
 		Entity damager = event.getDamager();
 		Entity target = event.getEntity();
 
-		if (!(damager instanceof Trident))
+		if (!(damager instanceof Trident trident))
 			return;
 
-		if (!damager.getPersistentDataContainer().has(wipeTrident, PersistentDataType.INTEGER))
+		if (!damager.getPersistentDataContainer().has(wipeTridentKey(), PersistentDataType.INTEGER))
 			return;
 
-		// Fire the lightning
-		target.getWorld().strikeLightning(event.getEntity().getLocation()).setCausingPlayer((Player) ((Projectile) damager).getShooter());
+		if (!(trident.getShooter() instanceof Player shooter))
+			return;
+
+		target.getWorld().strikeLightning(event.getEntity().getLocation()).setCausingPlayer(shooter);
 		target.getWorld().playSound(event.getEntity().getLocation(), Sound.ITEM_TRIDENT_THUNDER, 1000, 1);
 	}
 }

--- a/src/main/java/ourstory/events/onVulnerabilitySeeker.java
+++ b/src/main/java/ourstory/events/onVulnerabilitySeeker.java
@@ -3,12 +3,9 @@ package ourstory.events;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-
-import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.Particle;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
@@ -16,101 +13,114 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.plugin.Plugin;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.util.Vector;
-
 import io.papermc.paper.event.player.PlayerStopUsingItemEvent;
+import ourstory.Main;
 import ourstory.utils.EnchantItem;
+import org.bukkit.Particle;
 
 /**
  *
  * @author aurel
  */
 public class onVulnerabilitySeeker implements Listener {
-	private final Plugin p = Bukkit.getPluginManager().getPlugin("OurStory");
-	private final HashMap<UUID, Boolean> runningTasks = new HashMap<>();
-	private final Map<Entity, BukkitRunnable> particleColorTimer = new HashMap<>();
-	private final int effectTimer = 1200;
-	private final Color effectColor = Color.fromRGB(143, 69, 237);
+
+	private static final int EFFECT_TIMER = 1200;
+	private static final Color EFFECT_COLOR = Color.fromRGB(143, 69, 237);
+
+	private final Map<UUID, BukkitRunnable> seekerTasks = new HashMap<>();
+	private final Map<UUID, BukkitRunnable> particleTasks = new HashMap<>();
 
 	@EventHandler
 	public void applyEffectWithSpyglass(PlayerInteractEvent event) {
-		if (event == null || event.getItem() == null)
-			return;
 		ItemStack item = event.getItem();
-		if (item.getType() != Material.SPYGLASS)
+		if (item == null || item.getType() != Material.SPYGLASS)
 			return;
 		if (event.getAction() != Action.RIGHT_CLICK_AIR && event.getAction() != Action.RIGHT_CLICK_BLOCK)
 			return;
+
 		Player player = event.getPlayer();
 		UUID playerUUID = player.getUniqueId();
 
-		if (!runningTasks.containsKey(playerUUID))
-			runningTasks.put(playerUUID, false);
-		runningTasks.replace(playerUUID, true);
+		cancelSeeker(playerUUID);
 
 		BukkitRunnable task = new BukkitRunnable() {
 			@Override
 			public void run() {
-				int vulneSeekLevel = EnchantItem.getEnchantAmount(item, "vulnerability_seeker");
+				ItemStack held = player.getInventory().getItemInMainHand();
+				if (held.getType() != Material.SPYGLASS) {
+					cancelSeeker(playerUUID);
+					return;
+				}
 
-				if ((vulneSeekLevel > 0) && runningTasks.get(playerUUID)) {
-					Vector direction = player.getEyeLocation().getDirection();
-					RayTraceResult result = player.getWorld().rayTraceEntities(player.getEyeLocation(), direction, 50, entity -> entity instanceof Entity && entity != player);
-					if (result != null && result.getHitEntity() instanceof LivingEntity) {
-						((LivingEntity) result.getHitEntity()).addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, effectTimer, 1, false, false, true));
-						((LivingEntity) result.getHitEntity()).addPotionEffect(new PotionEffect(PotionEffectType.WEAKNESS, effectTimer, 2, false, false, true));
-						startParticleEffect(result.getHitEntity());
-					}
+				int vulneSeekLevel = EnchantItem.getEnchantAmount(held, "vulnerability_seeker");
+				if (vulneSeekLevel <= 0)
+					return;
+
+				Vector direction = player.getEyeLocation().getDirection();
+				RayTraceResult result = player.getWorld().rayTraceEntities(
+						player.getEyeLocation(), direction, 50,
+						entity -> entity != player);
+
+				if (result != null && result.getHitEntity() instanceof LivingEntity living) {
+					living.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, EFFECT_TIMER, 1, false, false, true));
+					living.addPotionEffect(new PotionEffect(PotionEffectType.WEAKNESS, EFFECT_TIMER, 2, false, false, true));
+					startParticleEffect(living);
 				}
 			}
 		};
-		task.runTaskTimer(p, 0, 1); // Exécutez chaque tick
+		seekerTasks.put(playerUUID, task);
+		task.runTaskTimer(Main.plugin, 0, 1);
 	}
 
 	@EventHandler
-	public void applyEffectWithSpyglass(PlayerStopUsingItemEvent event) {
-		if (event == null)
-			return;
+	public void stopSpyglassUse(PlayerStopUsingItemEvent event) {
 		if (event.getItem().getType() != Material.SPYGLASS)
 			return;
-		UUID playerUUID = event.getPlayer().getUniqueId();
-		if (runningTasks.containsKey(playerUUID))
-			runningTasks.replace(playerUUID, false);
+		cancelSeeker(event.getPlayer().getUniqueId());
 	}
 
-	public void startParticleEffect(Entity entity) {
-		cancelExistingTimer(entity);
+	@EventHandler
+	public void onQuit(PlayerQuitEvent event) {
+		cancelSeeker(event.getPlayer().getUniqueId());
+	}
+
+	private void cancelSeeker(UUID playerUUID) {
+		BukkitRunnable existing = seekerTasks.remove(playerUUID);
+		if (existing != null && !existing.isCancelled())
+			existing.cancel();
+	}
+
+	private void startParticleEffect(Entity entity) {
+		cancelExistingTimer(entity.getUniqueId());
 		BukkitRunnable particleTask = new BukkitRunnable() {
-			int timeLeft = effectTimer;
+			int timeLeft = EFFECT_TIMER;
 
 			@Override
 			public void run() {
-				if (timeLeft <= 0) {
+				if (entity.isDead() || timeLeft <= 0) {
+					particleTasks.remove(entity.getUniqueId());
 					this.cancel();
-					particleColorTimer.remove(entity);
-				} else {
-					Location location = entity.getLocation().add(0, 0.5, 0);
-					entity.getWorld().spawnParticle(Particle.ENTITY_EFFECT, location, 5, effectColor);
-					timeLeft -= 5L;
+					return;
 				}
+				Location location = entity.getLocation().add(0, 0.5, 0);
+				entity.getWorld().spawnParticle(Particle.ENTITY_EFFECT, location, 5, EFFECT_COLOR);
+				timeLeft -= 5;
 			}
 		};
-
-		particleTask.runTaskTimer(p, 0L, 5L);
-		particleColorTimer.put(entity, particleTask);
+		particleTask.runTaskTimer(Main.plugin, 0L, 5L);
+		particleTasks.put(entity.getUniqueId(), particleTask);
 	}
 
-	public void cancelExistingTimer(Entity entity) {
-		BukkitRunnable existingTask = particleColorTimer.get(entity);
-		if (existingTask != null) {
-			existingTask.cancel();
-			particleColorTimer.remove(entity);
-		}
+	private void cancelExistingTimer(UUID entityId) {
+		BukkitRunnable existing = particleTasks.remove(entityId);
+		if (existing != null && !existing.isCancelled())
+			existing.cancel();
 	}
 }

--- a/src/main/java/ourstory/events/onZombieDeath.java
+++ b/src/main/java/ourstory/events/onZombieDeath.java
@@ -1,7 +1,6 @@
 package ourstory.events;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import org.bukkit.Material;
 import org.bukkit.damage.DamageSource;
@@ -15,10 +14,7 @@ import org.bukkit.inventory.ItemStack;
 import ourstory.utils.EnchantItem;
 
 public class onZombieDeath implements Listener {
-	/*
-	 * If a zombie if killed by fire, makes him drop leather instead of rotten flesh
-	 */
-	private final List<EntityType> zombies = Arrays.asList(
+	private static final List<EntityType> ZOMBIES = List.of(
 			EntityType.ZOMBIE,
 			EntityType.HUSK,
 			EntityType.DROWNED,
@@ -26,38 +22,34 @@ public class onZombieDeath implements Listener {
 			EntityType.ZOMBIE_VILLAGER,
 			EntityType.ZOGLIN);
 
-
 	@EventHandler
 	public void zombieDeath(EntityDeathEvent entity) {
-		if (!zombies.contains(entity.getEntityType()))
+		if (!ZOMBIES.contains(entity.getEntityType()))
 			return;
 
 		boolean killedByFire = false;
 		DamageSource source = entity.getDamageSource();
+		if (source == null)
+			return;
 
-		// Check if killed from fire_aspect
-		if (source.getDamageType() == DamageType.PLAYER_ATTACK) {
-			Player p = (Player) source.getCausingEntity();
+		if (source.getDamageType() == DamageType.PLAYER_ATTACK && source.getCausingEntity() instanceof Player p) {
 			ItemStack weapon = p.getInventory().getItemInMainHand();
-
 			killedByFire = EnchantItem.getEnchantAmount(weapon, "fire_aspect") > 0;
+		} else if (source.getDamageType() == DamageType.ARROW && source.getDirectEntity() != null) {
+			killedByFire = source.getDirectEntity().getFireTicks() > 0;
 		}
 
-		// Check if killed by flamed arrow
-		if (source.getDamageType() == DamageType.ARROW)
-			killedByFire = source.getDirectEntity().getFireTicks() > 0;
+		if (!killedByFire && entity.getEntity().getFireTicks() <= 0)
+			return;
 
-		if (killedByFire || entity.getEntity().getFireTicks() > 0) {
-			List<ItemStack> temp = new ArrayList<>();
+		List<ItemStack> rottenFlesh = new ArrayList<>();
+		for (ItemStack drop : entity.getDrops())
+			if (drop.getType() == Material.ROTTEN_FLESH)
+				rottenFlesh.add(drop);
 
-			for (ItemStack drop : entity.getDrops())
-				if (drop.getType() == Material.ROTTEN_FLESH)
-					temp.add(drop);
-
-			for (ItemStack d : temp) {
-				entity.getDrops().add(new ItemStack(Material.LEATHER, d.getAmount()));
-				entity.getDrops().remove(d);
-			}
+		for (ItemStack d : rottenFlesh) {
+			entity.getDrops().add(new ItemStack(Material.LEATHER, d.getAmount()));
+			entity.getDrops().remove(d);
 		}
 	}
 }

--- a/src/main/java/ourstory/goal/ChargeClosestGoal.java
+++ b/src/main/java/ourstory/goal/ChargeClosestGoal.java
@@ -15,23 +15,20 @@ import com.destroystokyo.paper.entity.ai.GoalKey;
 import com.destroystokyo.paper.entity.ai.GoalType;
 import com.google.common.collect.ImmutableSet;
 import io.papermc.paper.entity.LookAnchor;
-import net.kyori.adventure.text.Component;
 import ourstory.bosses.Boss;
 import ourstory.spells.Spell;
 
 public final class ChargeClosestGoal implements Goal<Mob> {
-	private static final Integer COOLDOWN = 20 * 10;
-	private static final Integer SCAN_RADIUS = 20;
+	private static final int COOLDOWN_TICKS = 20 * 10;
+	private static final int SCAN_RADIUS = 20;
+
 	private final Boss boss;
+	private final ImmutableSet<Spell> spells;
+
 	private Player target;
 	private Location lastTargetLoc;
 	private Location originalLoc;
-
-	private final ImmutableSet<Spell> spells;
-	/**
-	 * Last time (in server ticks) the behaviour has been triggered
-	 */
-	private Integer lastTickActivated;
+	private int lastTickActivated = Integer.MIN_VALUE / 2;
 
 	public ChargeClosestGoal(final Boss boss, final ImmutableSet<Spell> spells) {
 		this.boss = boss;
@@ -39,19 +36,23 @@ public final class ChargeClosestGoal implements Goal<Mob> {
 	}
 
 	private Optional<Player> getClosest(Collection<Player> players) {
-		double mindist = Integer.MAX_VALUE;
-		Player player = null;
-		for (var p : players) {
-			if (p.getLocation().distance(boss.entity.getLocation()) < mindist) {
-				player = p;
+		double minDistance = Double.MAX_VALUE;
+		Player closest = null;
+		Location bossLoc = boss.entity.getLocation();
+		for (Player p : players) {
+			double d = p.getLocation().distance(bossLoc);
+			if (d < minDistance) {
+				minDistance = d;
+				closest = p;
 			}
 		}
-		return Optional.ofNullable(player);
+		return Optional.ofNullable(closest);
 	}
 
 	@Override
 	public void start() {
-		Bukkit.getServer().broadcast(Component.text("[ChargeGoal] - Targetting ").append(target.name()));
+		if (target == null)
+			return;
 		boss.entity.lookAt(
 				target.getEyeLocation().x(),
 				target.getEyeLocation().y(),
@@ -64,18 +65,8 @@ public final class ChargeClosestGoal implements Goal<Mob> {
 
 	@Override
 	public void tick() {
-		// if (!("should spell stop")) {
-		// // tick spell
-		// return;
-		// }
-		// stop du spell
-
-		// quand on tire un spell
-		// le spell s'exécute
-		// setup du spell
-
-
-		Bukkit.getServer().broadcast(Component.text(String.format("[ChargeGoal] - Charging!!!")));
+		if (lastTargetLoc == null)
+			return;
 		boss.entity.lookAt(lastTargetLoc);
 		boss.entity.getPathfinder().moveTo(lastTargetLoc, 2);
 		boss.entity.getWorld().spawnParticle(Particle.ANGRY_VILLAGER,
@@ -84,19 +75,14 @@ public final class ChargeClosestGoal implements Goal<Mob> {
 
 	@Override
 	public void stop() {
+		if (target == null)
+			return;
 		if (target.getLocation().distance(boss.entity.getLocation()) < 5.0D) {
-			var delta = new Vector(
-					target.getX(),
-					target.getY(),
-					target.getZ()).subtract(
-							new Vector(
-									boss.entity.getX(),
-									boss.entity.getY(),
-									boss.entity.getZ()));
+			Vector delta = new Vector(target.getX(), target.getY(), target.getZ())
+					.subtract(new Vector(boss.entity.getX(), boss.entity.getY(), boss.entity.getZ()));
 			target.knockback(2, -delta.getX(), -delta.getZ());
 		}
-		Bukkit.broadcast(Component.text("[ChargeGoal] - Stop"));
-		this.lastTickActivated = Bukkit.getCurrentTick();
+		lastTickActivated = Bukkit.getCurrentTick();
 	}
 
 	@Override
@@ -104,8 +90,7 @@ public final class ChargeClosestGoal implements Goal<Mob> {
 		Collection<Player> nearbyPlayers = boss.entity.getLocation().getNearbyPlayers(SCAN_RADIUS, boss.targets::contains);
 		Optional<Player> closest = getClosest(nearbyPlayers);
 		int currentTick = Bukkit.getCurrentTick();
-		Bukkit.broadcast(Component.text(String.format("[ChargeGoal] - cooldown=%d", currentTick - lastTickActivated)));
-		if (closest.isPresent() && currentTick - lastTickActivated > COOLDOWN) {
+		if (closest.isPresent() && currentTick - lastTickActivated > COOLDOWN_TICKS) {
 			this.target = closest.get();
 			this.lastTickActivated = currentTick;
 			return true;
@@ -115,16 +100,13 @@ public final class ChargeClosestGoal implements Goal<Mob> {
 
 	@Override
 	public boolean shouldStayActive() {
-		boolean f = boss.entity.getLocation().distance(lastTargetLoc) > 2.0D;
-		Bukkit.broadcast(Component.text(String.format("[ChargeGoal] - ShouldStayActive=%b", f)));
-		return f;
+		return lastTargetLoc != null
+				&& boss.entity.getLocation().distance(lastTargetLoc) > 2.0D;
 	}
 
 	@Override
 	public GoalKey<Mob> getKey() {
-		return GoalKey.of(
-				Mob.class,
-				new NamespacedKey("ourstory", "boss_goal_charge"));
+		return GoalKey.of(Mob.class, new NamespacedKey("ourstory", "boss_goal_charge"));
 	}
 
 	@Override

--- a/src/main/java/ourstory/goal/Phase1.java
+++ b/src/main/java/ourstory/goal/Phase1.java
@@ -1,31 +1,20 @@
 package ourstory.goal;
 
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Set;
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Mob;
-import org.bukkit.entity.Player;
 import com.destroystokyo.paper.entity.ai.Goal;
 import com.destroystokyo.paper.entity.ai.GoalKey;
 import com.destroystokyo.paper.entity.ai.GoalType;
-import net.kyori.adventure.text.Component;
 import ourstory.bosses.Boss;
 import ourstory.spells.Spell;
 
 public final class Phase1 implements Goal<Mob> {
 	private final Boss boss;
-	private Player target;
-	private Location lastTargetLoc;
-
+	@SuppressWarnings("unused")
 	private final Set<Spell> spells;
-	/**
-	 * Last time (in server ticks) the behaviour has been triggered
-	 */
-	private Integer lastTickActivated;
 
 	public Phase1(final Boss boss, final Set<Spell> spells) {
 		this.boss = boss;
@@ -34,22 +23,25 @@ public final class Phase1 implements Goal<Mob> {
 
 	@Override
 	public void start() {
-		Bukkit.getServer().broadcast(Component.text("[Phase1] - Setup "));
+		// no-op
 	}
 
 	@Override
 	public void tick() {
-		Bukkit.getServer().broadcast(Component.text("[Phase1] - Running "));
+		// no-op
 	}
 
 	@Override
 	public void stop() {
-		Bukkit.getServer().broadcast(Component.text("[Phase1] - Stop "));
+		// no-op
 	}
 
 	@Override
 	public boolean shouldActivate() {
-		return (this.boss.entity.getHealth() / this.boss.entity.getAttribute(Attribute.MAX_HEALTH).getValue()) > 0.5;
+		double max = this.boss.entity.getAttribute(Attribute.MAX_HEALTH).getValue();
+		if (max <= 0)
+			return false;
+		return (this.boss.entity.getHealth() / max) > 0.5;
 	}
 
 	@Override

--- a/src/main/java/ourstory/goal/Phase2.java
+++ b/src/main/java/ourstory/goal/Phase2.java
@@ -1,31 +1,20 @@
 package ourstory.goal;
 
 import java.util.EnumSet;
-import java.util.List;
 import java.util.Set;
-import org.bukkit.Bukkit;
-import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Mob;
-import org.bukkit.entity.Player;
 import com.destroystokyo.paper.entity.ai.Goal;
 import com.destroystokyo.paper.entity.ai.GoalKey;
 import com.destroystokyo.paper.entity.ai.GoalType;
-import net.kyori.adventure.text.Component;
 import ourstory.bosses.Boss;
 import ourstory.spells.Spell;
 
 public final class Phase2 implements Goal<Mob> {
 	private final Boss boss;
-	private Player target;
-	private Location lastTargetLoc;
-
+	@SuppressWarnings("unused")
 	private final Set<Spell> spells;
-	/**
-	 * Last time (in server ticks) the behaviour has been triggered
-	 */
-	private Integer lastTickActivated;
 
 	public Phase2(final Boss boss, final Set<Spell> spells) {
 		this.boss = boss;
@@ -34,22 +23,25 @@ public final class Phase2 implements Goal<Mob> {
 
 	@Override
 	public void start() {
-		Bukkit.getServer().broadcast(Component.text("[Phase2] - Setup "));
+		// no-op
 	}
 
 	@Override
 	public void tick() {
-		Bukkit.getServer().broadcast(Component.text("[Phase2] - Running "));
+		// no-op
 	}
 
 	@Override
 	public void stop() {
-		Bukkit.getServer().broadcast(Component.text("[Phase2] - Stop "));
+		// no-op
 	}
 
 	@Override
 	public boolean shouldActivate() {
-		return (this.boss.entity.getHealth() / this.boss.entity.getAttribute(Attribute.MAX_HEALTH).getValue()) < 0.5;
+		double max = this.boss.entity.getAttribute(Attribute.MAX_HEALTH).getValue();
+		if (max <= 0)
+			return false;
+		return (this.boss.entity.getHealth() / max) < 0.5;
 	}
 
 	@Override

--- a/src/main/java/ourstory/goal/SleepGoal.java
+++ b/src/main/java/ourstory/goal/SleepGoal.java
@@ -1,13 +1,11 @@
 package ourstory.goal;
 
 import java.util.EnumSet;
-import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Mob;
 import com.destroystokyo.paper.entity.ai.Goal;
 import com.destroystokyo.paper.entity.ai.GoalKey;
 import com.destroystokyo.paper.entity.ai.GoalType;
-import net.kyori.adventure.text.Component;
 import ourstory.bosses.Boss;
 
 public class SleepGoal implements Goal<Mob> {
@@ -24,14 +22,12 @@ public class SleepGoal implements Goal<Mob> {
 
 	@Override
 	public void tick() {
-		Bukkit.getServer().broadcast(Component.text("[SleepGoal] - zZz...zZz"));
+		// no-op: boss is "sleeping"
 	}
 
 	@Override
 	public GoalKey<Mob> getKey() {
-		return GoalKey.of(
-				Mob.class,
-				new NamespacedKey("ourstory", "boss_goal_sleep"));
+		return GoalKey.of(Mob.class, new NamespacedKey("ourstory", "boss_goal_sleep"));
 	}
 
 	@Override

--- a/src/main/java/ourstory/guilds/Guild.java
+++ b/src/main/java/ourstory/guilds/Guild.java
@@ -22,11 +22,9 @@ public class Guild {
 	}
 
 	public JSONObject toJson() {
-		JSONObject guild = new JSONObject()
-				.put("id", id)
+		return new JSONObject()
+				.put("uuid", id.toString())
 				.put("name", name)
 				.put("bank", bank);
-
-		return guild;
 	}
 }

--- a/src/main/java/ourstory/spells/Annihilation.java
+++ b/src/main/java/ourstory/spells/Annihilation.java
@@ -11,21 +11,20 @@ import net.kyori.adventure.text.Component;
 
 public class Annihilation extends Spell {
 	/*
-	 * Special skill, last skill only used in chaos mode. Triggers at 20% HP remaining. The boss invokes
-	 * a flame circle arround him and deals a lot of damages.
+	 * Special skill, last skill only used in chaos mode. Triggers at 20% HP remaining.
+	 * The caster invokes a flame circle around itself and deals heavy damage.
 	 */
 	private Location loc;
 	private int pointCount;
 	private double radius;
 	private int totalSteps;
-	private double radiusIncrease, startRadius, endRadius;
+	private double radiusIncrease;
+	private double startRadius;
+	private double endRadius;
 	private int t;
-	private Entity caster;
 
 	public Annihilation(Entity caster, List<Entity> targets, int level) {
 		super(caster, targets, level);
-		this.caster = caster;
-		this.level = level;
 	}
 
 	@Override
@@ -44,14 +43,11 @@ public class Annihilation extends Spell {
 
 	@Override
 	public void tick() {
+		double progress = (double) t / totalSteps;
+		double easedProgress = 1 - Math.pow(1 - progress, 2);
+
 		for (int i = 0; i < pointCount; i++) {
 			double angle = 2 * Math.PI * i / pointCount;
-
-			this.t = 0;
-
-			double progress = (double) t / totalSteps;
-			double easedProgress = 1 - Math.pow(1 - progress, 2);
-
 			double currentRadius = radius * (1 - easedProgress);
 			double currentAngle = angle + Math.PI * easedProgress;
 
@@ -60,22 +56,21 @@ public class Annihilation extends Spell {
 			Location particleLoc = loc.clone().add(x, 0, z);
 
 			caster.getWorld().spawnParticle(Particle.LARGE_SMOKE, particleLoc, 0, 0, 0, 0, 0);
-			t++;
 		}
+		t++;
 
 		playCircleEffect(caster, loc, startRadius);
 		startRadius += radiusIncrease;
-		List<Entity> nearbyEntities = caster.getNearbyEntities(startRadius, 2, startRadius);
-		for (Entity entity : nearbyEntities) {
-			// Push the entity
+		for (Entity entity : caster.getNearbyEntities(startRadius, 2, startRadius)) {
+			if (!(entity instanceof LivingEntity livingTarget))
+				continue;
+			if (entity.equals(caster))
+				continue;
+
 			Vector direction = entity.getLocation().toVector().subtract(loc.toVector()).normalize();
 			entity.setVelocity(direction.multiply(0.7));
-
-			// Damage if player
-			LivingEntity livingTarget = (LivingEntity) entity;
 			livingTarget.damage(7.0);
 		}
-
 	}
 
 	@Override
@@ -84,7 +79,9 @@ public class Annihilation extends Spell {
 	}
 
 	@Override
-	public void stop() {}
+	public void stop() {
+		// no-op
+	}
 
 	private static void playCircleEffect(Entity caster, Location loc, double radius) {
 		for (double angle = 0; angle < 2 * Math.PI; angle += Math.PI / 150) {

--- a/src/main/java/ourstory/spells/ArcanicShield.java
+++ b/src/main/java/ourstory/spells/ArcanicShield.java
@@ -40,26 +40,22 @@ public class ArcanicShield extends Spell {
 
 	@Override
 	public void setup() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'setup'");
+		// not yet implemented; see commented WIP below
 	}
 
 	@Override
 	public void tick() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'tick'");
+		// not yet implemented
 	}
 
 	@Override
 	public void stop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'stop'");
+		// not yet implemented
 	}
 
 	@Override
 	public boolean shouldStop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'shouldStop'");
+		return true;
 	}
 
 	// @Override

--- a/src/main/java/ourstory/spells/ArrowWall.java
+++ b/src/main/java/ourstory/spells/ArrowWall.java
@@ -17,26 +17,22 @@ public class ArrowWall extends Spell {
 
 	@Override
 	public void setup() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'setup'");
+		// not yet implemented; see commented WIP below
 	}
 
 	@Override
 	public void tick() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'tick'");
+		// not yet implemented
 	}
 
 	@Override
 	public void stop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'stop'");
+		// not yet implemented
 	}
 
 	@Override
 	public boolean shouldStop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'shouldStop'");
+		return true;
 	}
 
 	// @Override

--- a/src/main/java/ourstory/spells/DarkAura.java
+++ b/src/main/java/ourstory/spells/DarkAura.java
@@ -16,20 +16,17 @@ public class DarkAura extends Spell {
 
 	@Override
 	public void setup() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'setup'");
+		// not yet implemented; see commented WIP below
 	}
 
 	@Override
 	public void tick() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'tick'");
+		// not yet implemented
 	}
 
 	@Override
 	public void stop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'stop'");
+		// not yet implemented
 	}
 	// @Override
 	// public void cast(Entity caster, List<Entity> targets, int level) {
@@ -37,8 +34,7 @@ public class DarkAura extends Spell {
 
 	@Override
 	public boolean shouldStop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'shouldStop'");
+		return true;
 	}
 
 	// // animation()

--- a/src/main/java/ourstory/spells/Growth.java
+++ b/src/main/java/ourstory/spells/Growth.java
@@ -22,26 +22,22 @@ public class Growth extends Spell {
 
 	@Override
 	public void setup() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'setup'");
+		// not yet implemented; see commented WIP below
 	}
 
 	@Override
 	public void tick() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'tick'");
+		// not yet implemented
 	}
 
 	@Override
 	public void stop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'stop'");
+		// not yet implemented
 	}
 
 	@Override
 	public boolean shouldStop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'shouldStop'");
+		return true;
 	}
 
 	// static NamespacedKey GrowthKey = new

--- a/src/main/java/ourstory/spells/LaserExplosion.java
+++ b/src/main/java/ourstory/spells/LaserExplosion.java
@@ -18,26 +18,22 @@ public class LaserExplosion extends Spell {
 
 	@Override
 	public void setup() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'setup'");
+		// not yet implemented; see commented WIP below
 	}
 
 	@Override
 	public void tick() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'tick'");
+		// not yet implemented
 	}
 
 	@Override
 	public void stop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'stop'");
+		// not yet implemented
 	}
 
 	@Override
 	public boolean shouldStop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'shouldStop'");
+		return true;
 	}
 
 	// @Override

--- a/src/main/java/ourstory/spells/LaserMatrix.java
+++ b/src/main/java/ourstory/spells/LaserMatrix.java
@@ -17,26 +17,22 @@ public class LaserMatrix extends Spell {
 
 	@Override
 	public void setup() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'setup'");
+		// not yet implemented; see commented WIP below
 	}
 
 	@Override
 	public void tick() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'tick'");
+		// not yet implemented
 	}
 
 	@Override
 	public void stop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'stop'");
+		// not yet implemented
 	}
 
 	@Override
 	public boolean shouldStop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'shouldStop'");
+		return true;
 	}
 
 	// @Override

--- a/src/main/java/ourstory/spells/RavenousVortex.java
+++ b/src/main/java/ourstory/spells/RavenousVortex.java
@@ -27,20 +27,17 @@ public class RavenousVortex extends Spell {
 
 	@Override
 	public void setup() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'setup'");
+		// not yet implemented; see commented WIP below
 	}
 
 	@Override
 	public void tick() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'tick'");
+		// not yet implemented
 	}
 
 	@Override
 	public void stop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'stop'");
+		// not yet implemented
 	}
 	// final static NamespacedKey GravityKey = new NamespacedKey(plugin, "boss_ravenous_vortex");
 	// final static double effectRange = 10;
@@ -49,8 +46,7 @@ public class RavenousVortex extends Spell {
 
 	@Override
 	public boolean shouldStop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'shouldStop'");
+		return true;
 	}
 
 	// @Override

--- a/src/main/java/ourstory/spells/Summon.java
+++ b/src/main/java/ourstory/spells/Summon.java
@@ -21,20 +21,17 @@ public class Summon extends Spell {
 
 	@Override
 	public void setup() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'setup'");
+		// not yet implemented; see commented WIP below
 	}
 
 	@Override
 	public void tick() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'tick'");
+		// not yet implemented
 	}
 
 	@Override
 	public void stop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'stop'");
+		// not yet implemented
 	}
 	// @Override
 	// public void cast(Entity caster, List<Entity> targets, int level) {
@@ -46,8 +43,7 @@ public class Summon extends Spell {
 
 	@Override
 	public boolean shouldStop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'shouldStop'");
+		return true;
 	}
 
 	// EntityEquipment equipment = minion.getEquipment();

--- a/src/main/java/ourstory/spells/SummonWarden.java
+++ b/src/main/java/ourstory/spells/SummonWarden.java
@@ -20,20 +20,17 @@ public class SummonWarden extends Spell {
 
 	@Override
 	public void setup() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'setup'");
+		// not yet implemented; see commented WIP below
 	}
 
 	@Override
 	public void tick() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'tick'");
+		// not yet implemented
 	}
 
 	@Override
 	public void stop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'stop'");
+		// not yet implemented
 	}
 	// @Override
 	// public void cast(Entity caster, List<Entity> targets, int level) {
@@ -44,8 +41,7 @@ public class SummonWarden extends Spell {
 
 	@Override
 	public boolean shouldStop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'shouldStop'");
+		return true;
 	}
 
 	// world.spawnParticle(Particle.REVERSE_PORTAL, summonPlace, 80, 0.7, 1, 0.7, 0.02);

--- a/src/main/java/ourstory/spells/Teleport.java
+++ b/src/main/java/ourstory/spells/Teleport.java
@@ -12,25 +12,21 @@ public class Teleport extends Spell {
 
 	@Override
 	public void setup() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'setup'");
+		// not yet implemented
 	}
 
 	@Override
 	public void tick() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'tick'");
+		// not yet implemented
 	}
 
 	@Override
 	public void stop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'stop'");
+		// not yet implemented
 	}
 
 	@Override
 	public boolean shouldStop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'shouldStop'");
+		return true;
 	}
 }

--- a/src/main/java/ourstory/spells/Wave.java
+++ b/src/main/java/ourstory/spells/Wave.java
@@ -14,26 +14,22 @@ public class Wave extends Spell {
 
 	@Override
 	public void setup() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'setup'");
+		// not yet implemented; see commented WIP below
 	}
 
 	@Override
 	public void tick() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'tick'");
+		// not yet implemented
 	}
 
 	@Override
 	public void stop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'stop'");
+		// not yet implemented
 	}
 
 	@Override
 	public boolean shouldStop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'shouldStop'");
+		return true;
 	}
 
 	// @Override

--- a/src/main/java/ourstory/spells/WitherRage.java
+++ b/src/main/java/ourstory/spells/WitherRage.java
@@ -17,26 +17,22 @@ public class WitherRage extends Spell {
 
 	@Override
 	public void setup() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'setup'");
+		// not yet implemented; see commented WIP below
 	}
 
 	@Override
 	public void tick() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'tick'");
+		// not yet implemented
 	}
 
 	@Override
 	public void stop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'stop'");
+		// not yet implemented
 	}
 
 	@Override
 	public boolean shouldStop() {
-		// TODO Auto-generated method stub
-		throw new UnsupportedOperationException("Unimplemented method 'shouldStop'");
+		return true;
 	}
 
 	// @Override

--- a/src/main/java/ourstory/utils/DeathMessage.java
+++ b/src/main/java/ourstory/utils/DeathMessage.java
@@ -1,19 +1,29 @@
 package ourstory.utils;
 
 import java.util.Locale;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 import org.bukkit.entity.Player;
 import org.json.JSONArray;
+import org.json.JSONException;
 import ourstory.Main;
 
-public class DeathMessage {
+public final class DeathMessage {
+	private DeathMessage() {
+		throw new IllegalStateException("Utility class");
+	}
+
 	public static String getRandomDeathMessage(Locale locale, Player player) {
-		JSONArray deathMessages = Main.messages.getJSONArray("death");
-		Random random = new Random();
-		int rng = random.nextInt(deathMessages.length());
+		JSONArray deathMessages;
+		try {
+			deathMessages = Main.messages.getJSONArray("death");
+		} catch (JSONException e) {
+			return player.getName() + " died.";
+		}
 
-		String deathMessage = deathMessages.getString(rng).replace("[player]", player.getName());
+		if (deathMessages.length() == 0)
+			return player.getName() + " died.";
 
-		return deathMessage;
+		int rng = ThreadLocalRandom.current().nextInt(deathMessages.length());
+		return deathMessages.getString(rng).replace("[player]", player.getName());
 	}
 }

--- a/src/main/java/ourstory/utils/FileUtils.java
+++ b/src/main/java/ourstory/utils/FileUtils.java
@@ -1,29 +1,27 @@
 package ourstory.utils;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import org.bukkit.Bukkit;
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import ourstory.Main;
 import ourstory.guilds.Guild;
-import org.json.JSONArray;
 
-public class FileUtils {
-	/*
-	 * This private constructor hides the implicit public one
-	 */
+public final class FileUtils {
 	private FileUtils() {
 		throw new IllegalStateException("Utility class");
 	}
 
 	public static List<Guild> loadGuilds(String guildFile) {
 		List<Guild> guilds = new ArrayList<>();
-
 		JSONArray array = loadJsonArray(guildFile);
 
 		for (int i = 0; i < array.length(); i++)
@@ -33,53 +31,57 @@ public class FileUtils {
 	}
 
 	public static JSONArray loadJsonArray(String filename) {
-		if (!filename.endsWith(".json"))
-			filename.concat(".json");
-
-		String rawContent = FileUtils.readRawFile(filename);
-		JSONTokener jsonParser = new JSONTokener(rawContent);
-		JSONArray json = new JSONArray(jsonParser);
-
-		return json;
+		String rawContent = readRawFile(filename);
+		if (rawContent.isEmpty())
+			return new JSONArray();
+		return new JSONArray(new JSONTokener(rawContent));
 	}
 
 	public static JSONObject loadJsonObject(String filename) {
-		if (!filename.endsWith(".json"))
-			filename.concat(".json");
-
-		String rawContent = FileUtils.readRawFile(filename);
-		JSONTokener jsonParser = new JSONTokener(rawContent);
-		JSONObject json = new JSONObject(jsonParser);
-
-		return json;
+		String rawContent = readRawFile(filename);
+		if (rawContent.isEmpty())
+			return new JSONObject();
+		return new JSONObject(new JSONTokener(rawContent));
 	}
 
 	public static String readRawFile(String filename) {
-		if (!Main.configDir.exists())
-			Main.configDir.mkdir();
-
-		File f = new File(Main.configDir, filename);
+		File f = resolveInsideConfigDir(filename);
+		if (f == null || !f.isFile())
+			return "";
 		try {
-			return new String(Files.readAllBytes(f.toPath()), StandardCharsets.UTF_8);
+			return Files.readString(f.toPath(), StandardCharsets.UTF_8);
 		} catch (IOException e) {
-			System.err.println("Cannot open file " + filename + "!");
+			Bukkit.getLogger().log(Level.WARNING, "Cannot read " + filename, e);
+			return "";
 		}
-		return new String();
 	}
 
 	public static void writeRawFile(String filename, String content) {
-		if (!Main.configDir.exists())
-			Main.configDir.mkdir();
-
-		File f = new File(Main.configDir, filename);
-
+		File f = resolveInsideConfigDir(filename);
+		if (f == null)
+			return;
 		try {
-			FileWriter writer = new FileWriter(f.getAbsolutePath());
-			writer.write(content);
-			writer.flush();
-			writer.close();
+			Files.createDirectories(f.getParentFile().toPath());
+			Files.writeString(f.toPath(), content, StandardCharsets.UTF_8);
 		} catch (IOException e) {
-			System.err.println("Cannot write to file " + filename + " !");
+			Bukkit.getLogger().log(Level.WARNING, "Cannot write " + filename, e);
 		}
+	}
+
+	/*
+	 * Resolves a filename inside Main.configDir, rejecting any path that would escape
+	 * the directory (e.g. "../etc/passwd" or absolute paths). Returns null on rejection.
+	 */
+	private static File resolveInsideConfigDir(String filename) {
+		File configDir = Main.configDir;
+		if (configDir == null)
+			return null;
+		Path base = configDir.toPath().toAbsolutePath().normalize();
+		Path resolved = base.resolve(filename).toAbsolutePath().normalize();
+		if (!resolved.startsWith(base)) {
+			Bukkit.getLogger().warning("Rejected path outside configDir: " + filename);
+			return null;
+		}
+		return resolved.toFile();
 	}
 }

--- a/src/main/java/ourstory/utils/Permissions.java
+++ b/src/main/java/ourstory/utils/Permissions.java
@@ -4,17 +4,16 @@ import org.bukkit.command.CommandSender;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 
-public class Permissions {
-	public Permissions() {
-		throw new IllegalStateException("You cannot instanciate this class. It should only contain static methods.");
+public final class Permissions {
+	private Permissions() {
+		throw new IllegalStateException("Utility class, cannot be instantiated.");
 	}
 
 	public static boolean checkPermissions(CommandSender sender, String requestedPermission) {
-		boolean allowedPerm = sender.hasPermission(requestedPermission);
+		if (sender.hasPermission(requestedPermission))
+			return true;
 
-		if (!allowedPerm)
-			sender.sendMessage(Component.text("You do not have the permission to perform this command !").color(NamedTextColor.RED));
-
-		return allowedPerm;
+		sender.sendMessage(Component.text("You do not have the permission to perform this command !").color(NamedTextColor.RED));
+		return false;
 	}
 }


### PR DESCRIPTION
## Summary

End-to-end audit of the plugin source. Each commit is a focused theme so the diff is reviewable and easy to bisect/revert. 7 commits, 50 files, net **−63 LOC**, build is green (`mvn package`).

Highlights — the issues that would actually have hit the server, grouped by category:

### Crashes and corruption
- `HolyCow.onSpawn/onHit/onDeath` and `Talven.onSpawn/onHit/onDeath` all threw `UnsupportedOperationException`. The boss-death/hit listeners route to those methods, so any boss kill or hit would crash the listener thread. Same pattern across 12 stub spells (`ArcanicShield`, `ArrowWall`, `DarkAura`, …) — they all throw from `setup/tick/stop/shouldStop`, so `/cast` or any future mob-goal that scheduled them died mid-cycle.
- `onBossDeath` / `onBossHit` dereferenced `Main.runningInstance` unconditionally — NPE on the first non-boss death because there's no running fight.
- Multiple unchecked casts that crashed on plausible-but-not-expected damager/shooter types: `onTridentHit` (dispenser shooting a channeling trident), `onZombieDeath` (skeleton-arrow kills, non-Player causing entity), `onArrowRain` (non-Player shooter), `Annihilation` (Item entity near caster).
- `onPlayerInteract` and `onPlayerSit` dereferenced a possibly-null `getClickedBlock()`.
- `ChargeClosestGoal.lastTickActivated` was an unboxed Integer used in arithmetic before initialization — NPE on the first `shouldActivate`.

### Wrong outputs (silent)
- `onEntityDeath`: `killer.heal(totalLeechLevel / 2)` was integer division — heal=0 at level 1, rounded down at every odd level.
- `Annihilation`'s tick reset `t = 0` inside the per-point loop, freezing the ease curve at zero — animation was broken.
- `ChargeClosestGoal.getClosest()` never updated `minDistance`, so it returned the last-iterated player instead of the closest.
- `Count` used case-sensitive `Material.getMaterial`; users typing `iron_ingot` got "you need a valid item".
- `FileUtils.filename.concat(".json")` was a no-op (strings are immutable) — the result was discarded.

### Security
- `MobGoalCommand` had no permission check at all — any player could spawn a Holy Cow boss.
- `CancelDrop` (/itemlock) had no permission check, no instanceof guard, and would NPE on an empty hand.
- `Boss` command read `args[0]` but ignored it and always spawned Talven.
- `Cast` command's static block declared a local map and threw it away; the registered `skills` field was null. Replaced with a real factory map; only working spells exposed.
- `FileUtils` had no path-traversal guard. Callers pass hardcoded names today, but defense in depth.
- `plugin.yml` declared zero permissions — admins had no way to see or configure the `ourstory.*` nodes that commands check. Declared all of them with sensible defaults.

### Memory / CPU leaks
- `onVulnerabilitySeeker`: a per-tick raytrace task was started on every right-click but never cancelled. The `runningTasks` flag only gated the *body* of the task; the task itself kept polling forever, accumulating one per past right-click. Now tracked per player and torn down on stop-using and on quit.
- `onArrowRain`: the delayed runnable referenced the live `ProjectileHitEvent` and called `getHitEntity().getLocation()` each tick — NPE if the entity died/unloaded. Now snapshots the anchor once, validates shooter on each tick, and cleans the active-arrow counter on `PlayerQuit`.
- `onPhoenixDeath.savedEffects` leaked entries if the player quit between death and respawn — cleaned on quit.
- `onBreakVeine` was recursive (StackOverflow risk on long veins) **and** double-dropped at level 0 because it called `breakNaturally` on the same block the engine was already breaking. Rewritten as a bounded BFS; the source block is excluded from `breakNaturally`; returns early when the enchant isn't present.

### Infrastructure
- `pom.xml` had a duplicate `<project.build.sourceEncoding>` line.
- CI uploaded `target/OurStory.jar` but Maven built `target/Ourstory.jar` — the artifact was silently empty on case-sensitive Linux.
- `Main.configDir = new File(user.dir + "/plugins/Ourstory")` was both fragile (broke if the server was started from a non-root cwd) and case-mismatched against `plugin.yml`'s `name: OurStory` — Bukkit and the plugin disagreed about the data folder. Now uses `getDataFolder()`. `messages.json` is bundled as a resource and `saveResource`'d on first run.
- `Guild.toJson` wrote `"id"` while the constructor read `"uuid"` — round-tripping a guild through JSON threw.

### Misc polish
- Debug `Bukkit.broadcast` spam in `Phase1/Phase2/SleepGoal/ChargeClosestGoal` (every tick, to every online player) was removed.
- Standardized fragile `Bukkit.getPluginManager().getPlugin("OurStory")` field initializers on a single `Main.plugin` reference set in `onEnable`.
- PascalCase field names (`DummyName`, `ItemIsLocked`) renamed to Java conventions.
- `Permissions` had a public-but-throwing constructor with the typo "instanciate"; made private.

## Notes
- Stub spells (12 files) were left as **no-ops**, not deleted — the commented-out WIP implementations they contain look like work in progress, not abandoned code. Same call for the large commented blocks in `Talven`/`HolyCow`.
- Unregistered commands (`Reset`, `RankUp`, `Guild` skeleton, `Test`) were left alone for the same reason.
- `MetricsServer.java` is still a TODO placeholder.
- The `<mainClass>Main</mainClass>` in the shade plugin is dead config (Bukkit uses `plugin.yml`'s `main:`, not the manifest) but harmless — left alone.

## Test plan

- [x] `mvn package` builds cleanly (only the usual Guava-on-JDK-25 `sun.misc.Unsafe` deprecation warnings from Maven itself).
- [ ] Drop the jar on a test server and verify each command's permission check (`/goal`, `/boss`, `/dummy`, `/cast`, `/itemlock`, `/count`, `/chall`, `/split`) — non-ops should now get the "no permission" message instead of being able to spawn bosses.
- [ ] Smoke-test `/cast Annihilation` to confirm the animation actually progresses now (previously frozen at zero).
- [ ] Mine a vein of iron with a `veine_miner`-enchanted pickaxe and confirm: drops aren't doubled, no StackOverflow on large veins, and a non-enchanted pickaxe doesn't trigger the handler.
- [ ] Kill a mob with leech 1 and confirm health actually goes up (previously the integer division zeroed it).
- [ ] Use a spyglass repeatedly and confirm task count doesn't grow over time (was unbounded).
- [ ] Try `/count iron_ingot` (lowercase) and confirm it now finds items.
- [ ] Confirm CI uploads a non-empty artifact named `Ourstory.jar`.